### PR TITLE
docs: 修复未竟专题 PDF 书签链接问题

### DIFF
--- a/讲义/其它/未竟专题一 预备思想.tex
+++ b/讲义/其它/未竟专题一 预备思想.tex
@@ -1,5 +1,6 @@
-% FIXME: PDF 书签仍然链接到上一讲
+\begingroup
 \SetLUChapterNumberingStyle{0}
+\def\theHchapter{\arabic{chapter}ε}
 
 \chapter{预备思想}
 
@@ -280,7 +281,7 @@
 
 接下来我们来看皮亚诺是如何基于一些从直觉而来的原理，转化为少数几条公理使其能够构成一个完备的自然数理论体系的. 我们先从一个直觉性的不正式的定义出发，然后看皮亚诺如何将其公理化.
 
-\begin{definition}%[非正式的自然数定义]
+\begin{definition}%[非正式的自然数定义] %FIXME
     自然数是指集合
     \[\mathbf{N}=\{0,1,2,3,4,\ldots\}\]
     中的元素，此集合是由从0开始无休止地往前数所得到的一切数的集合. 我们将$\mathbf{N}$称为自然数集.
@@ -495,3 +496,4 @@
 \end{enumerate}
 
 \ResetChapterNumberingStyle{1}
+\endgroup

--- a/讲义/线性代数荣誉课辅学讲义.tex
+++ b/讲义/线性代数荣誉课辅学讲义.tex
@@ -46,7 +46,8 @@
 % 标题格式
 % \ResetChapterNumberingStyle 重置章节编号为正常样式
 % \SetLUChapterNumberingStyle 设置章节编号为未竟专题样式
-% 参数为下一章节编号减一
+% 参数为其上一章节的编号
+\newcounter{LUchapter}
 \NewDocumentCommand{\ResetChapterNumberingStyle}{m}{%
 \setcounter{chapter}{#1}
 \ctexset{
@@ -59,8 +60,9 @@
 }
 \NewDocumentCommand{\SetLUChapterNumberingStyle}{m}{%
 \setcounter{chapter}{#1}
+\refstepcounter{LUchapter}
 \ctexset{
-    chapter = {format={\centering\Huge\bfseries},name={未竟专题,},number=\zhnumber{\arabic{chapter}}},
+    chapter = {format={\centering\Huge\bfseries},name={未竟专题,},number={\zhnumber{\arabic{LUchapter}}}},
     section = {format={\raggedright\Large\bfseries},name={,},number={\texorpdfstring{\arabic{chapter}$\boldsymbol{\varepsilon}$}{\arabic{chapter}ε}.\arabic{section}}},
     subsection = {format={\raggedright\large\bfseries},name={,},number={\texorpdfstring{\arabic{chapter}$\boldsymbol{\varepsilon}$}{\arabic{chapter}ε}.\arabic{section}.\arabic{subsection}}},
     subsubsection = {format={\raggedright\normalsize\bfseries},name={,},number={\texorpdfstring{\arabic{chapter}$\boldsymbol{\varepsilon}$}{\arabic{chapter}ε}.\arabic{section}.\arabic{subsection}.\arabic{subsubsection}}},
@@ -74,7 +76,7 @@
 \author{2023--2024 学年线性代数 I/II（H）辅学授课 \\ 吴一航 \quad \verb|yhwu_is@zju.edu.cn|}
 
 \AtEndPreamble{\hypersetup{
-    % hypertexnames = false,
+    hypertexnames = true,
     pdfauthor = {吴一航},
     pdftitle = {线性代数荣誉课辅学讲义},
 }}


### PR DESCRIPTION
added `\begingroup` and `\endgroup` to restrict the scope of redefining `\theHchapter`