### PR TITLE
docs: 修改第 12 章教材相关内容，完善第 3, 9, 12 章答案

### DIFF
--- a/讲义/专题/12 行列式.tex
+++ b/讲义/专题/12 行列式.tex
@@ -140,7 +140,7 @@
 \end{definition}
 其中$A_{ij}$即为\autoref{def:余子式} 给出的代数余子式，\autoref{eq:13:递归式定义1} 称为$D$对第$j$列的展开式，\autoref{eq:13:递归式定义2} 称为$D$对第$i$行的展开式. 事实上，这一定义被称为递归式定义的原因是显然的（如果在程序设计课程中已经学习过递归的概念），它使用$n-1$阶行列式定义$n$阶行列式，因此我们对任意$n$阶行列式都可以递归展开到1阶，从而得到最终行列式计算结果.
 
-除此之外，我们需要强调的是，这里的递归式定义能称之为定义，必须要使得其与之前的公理化定义不冲突. 事实上二者等价的证明都是技术性的，教材175页定理5.1说明了我们如何从公理化定义推出递归式定义，反过来我们只需要对公理化定义中每个性质利用公理化定义逐个展开验算即可，我们放在习题中供感兴趣的读者自行验证. 因为都是技术性的问题，这里不展开叙述，事实上也不是我们核心的内容.
+除此之外，我们需要强调的是，这里的递归式定义能称之为定义，必须要使得其与之前的公理化定义不冲突. 事实上二者等价的证明都是技术性的，从公理化定义推出递归式定义需要利用公理化定义将原行列式进行拆分与变形，反过来我们只需要对公理化定义中每个性质利用递归式定义逐个展开验算即可，我们放在习题中供感兴趣的读者自行验证. 因为都是技术性的问题，这里不展开叙述，事实上也不是我们核心的内容.
 \begin{example}{}{递归式定义}
     利用\autoref{def:递归式定义} 计算\autoref{ex:余子式} 中的行列式，可以行列展开均使用并在上述公式中选取不同$i$和$j$以熟悉\autoref*{def:递归式定义}，并注意体会递归式定义的含义.
 \end{example}
@@ -238,11 +238,11 @@
         \item 对于 $|AB| = |A||B|$，分 $B$ 可逆与不可逆两种情况讨论：
 
             若 $B$ 可逆，则存在初等矩阵 $P_1, P_2, \ldots, P_k$，使得 $B = P_1 P_2 \cdots P_k$；由于右乘初等矩阵相当于对矩阵进行初等列变换，因此我们利用\ref*{item:13:行列式性质:3} 中的结论可以得到
-            \begin{align*}
+            \begin{gather*}
                 |A E_ij| = -|A| = |A||E_ij|, \\
                 |A E_i(c)| = c|A| = c|A||E_i(c)|, \\
                 |A E_{ij}(k)| = |A| = |A||E_{ij}(k)|.
-            \end{align*}
+            \end{gather*}
             因此，$|AB| = |A P_1 P_2 \cdots P_k| = |A||P_1||P_2|\cdots||P_k| = |A||B|$.
 
             若 $B$ 不可逆，则 $r(AB) \leqslant r(B) < n$，故 $AB$ 也不可逆. 组成不可逆的矩阵的列向量必线性相关，故由\autoref{ex:公理化定义} 的\ref*{item:13:公理化定义导出性质:5} 可知 $|B|=0, |AB|=0$，因此 $|AB| = 0 = |A||B|$.
@@ -501,25 +501,25 @@
     \begin{enumerate}
         \item （公理化定义与性质）由\autoref{def:公理化定义} 对该行列式进行展开操作（此处略去展开后有相同列向量的项），得到
             \begin{align*}
-                D =&\, \begin{vmatrix}
+                D = {} & \begin{vmatrix}
                     e_1 + 2e_2 + 3e_3 & 2e_1 + 3e_2 + e_3 & 3e_1 + e_2 + 2e_3
                 \end{vmatrix} \\
-                =&\, \begin{vmatrix}
+                = {} & \begin{vmatrix}
                     e_1 & 3e_2 & 2e_3
                 \end{vmatrix} + \begin{vmatrix}
                     e_1 & e_3 & e_2
                 \end{vmatrix} + \begin{vmatrix}
                     2e_2 & 2e_1 & 2e_3
                 \end{vmatrix} + \\
-                &\, \begin{vmatrix}
+                {} & \begin{vmatrix}
                     2e_2 & e_3 & 3e_1
                 \end{vmatrix} + \begin{vmatrix}
                     3e_3 & 2e_1 & e_2
                 \end{vmatrix} + \begin{vmatrix}
                     3e_3 & 3e_2 & 3e_1
                 \end{vmatrix} \\
-                =&\, 1 \cdot 3 \cdot 2 - 1 \cdot 1 \cdot 1 - 2 \cdot 2 \cdot 2 + 2 \cdot 1 \cdot 3 + 3 \cdot 2 \cdot 1 - 3 \cdot 3 \cdot 3 \\
-                =&\, -18.
+                = {} & 1 \cdot 3 \cdot 2 - 1 \cdot 1 \cdot 1 - 2 \cdot 2 \cdot 2 + 2 \cdot 1 \cdot 3 + 3 \cdot 2 \cdot 1 - 3 \cdot 3 \cdot 3 \\
+                = {} & -18.
             \end{align*}
             使用公理化定义展开行列式十分复杂，因此在实际运用中不推荐使用这一方法.
 
@@ -1584,10 +1584,10 @@
     \]
 
     类似地，我们有
-    \begin{align*}
-        A_{21} &= 3, \quad A_{22} = 0, \quad A_{23} = -1, \\
-        A_{31} &= 1, \quad A_{32} = 4, \quad A_{33} = -3,
-    \end{align*}
+    \begin{gather*}
+        A_{21} = 3, \quad A_{22} = 0, \quad A_{23} = -1, \\
+        A_{31} = 1, \quad A_{32} = 4, \quad A_{33} = -3,
+    \end{gather*}
 
     由此可得 $A$ 的伴随矩阵 $A^* = \begin{pmatrix}
             A_{11} & A_{21} & A_{31} \\
@@ -1900,8 +1900,151 @@
 
     \begin{exgroup}
         \item 证明：行列式的公理化定义、递归式定义和逆序数定义是等价的.
+        \begin{answer}
+            \begin{enumerate}
+                \item 公理化定义 $\implies$ 递归式定义：
+
+                    先证明一个引理：设 $A=(a_{ij})_{n \times n}$ 中 $a_{in}=0,\enspace i = 1, 2, \ldots, n-1$，则 $|A| = a_{nn} M_{nn} = a_{nn} A_{nn}$.
+
+                    将 $A$ 分块表示为
+                    \[
+                        A = \begin{pmatrix}
+                            A_1             & \mathbf{0} \\
+                            \mathbf{\alpha} & a_{nn}
+                        \end{pmatrix},
+                    \]
+
+                    其中 $|A_1| = M_{nn} = A_{nn}$. 若 $a_{nn} = 0$，则 $A$ 不可逆，$|A| = 0$，引理成立；若 $A_1$ 不可逆，则 $r(A) \leqslant r(A_1) + 1 < n$，故 $A$ 不可逆，$|A| = 0$，引理亦成立；若 $a_{nn} \neq 0$ 且 $A_1$ 可逆，则对 $A$ 作倍加列变换，有
+                    \[
+                        |A| = \begin{vmatrix}
+                            A_1             & \mathbf{0} \\
+                            \mathbf{0}      & a_{nn}
+                        \end{vmatrix}.
+                    \]
+
+                    再对 $A$ 作倍加行变换，将 $A_1$ 化为上三角矩阵 $B_1$，且有 $|B_1| = |A_1| = M_{nn}$，此时有
+                    \[
+                        |A| = \begin{vmatrix}
+                            B_1             & \mathbf{0} \\
+                            \mathbf{0}      & a_{nn}
+                        \end{vmatrix} = a_{nn} B_1 = a_{nn} M_{nn}.
+                    \]
+
+                    上式成立是因为上三角矩阵的行列式等于其对角线元素之积.
+
+                    下面我们来通过公理化定义推出递归式定义. 我们先推导行列式 $D=|a_{ij}|_{n \times n}$ 对第 $j$ 列元素的展开式：
+
+                    令 $\alpha_j$ 为 $A$ 中第 $j$ 列的元素，则由公理化定义可得
+                    \begin{align*}
+                        D &= D(\alpha_1, \alpha_2, \ldots, \alpha_j, \ldots, \alpha_n) \\
+                          &= D(\alpha_1, \alpha_2, \ldots, \sum_{i=1}^n a_{ij} e_i, \ldots, \alpha_n) \\
+                          &= \sum_{i=1}^n D(\alpha_1, \alpha_2, \ldots, a_{ij} e_i, \ldots, \alpha_n).
+                    \end{align*}
+                    对于上式中的第 $i$ 项 $D_i$，我们将第 $j$ 列依次与第 $j+1, j+2, \ldots, n$ 列对换，再将第 $i$ 行依次与第 $i+1, i+2, \ldots, n$ 行对换，于是有
+                    \[
+                        D_i = (-1)^{2n-i-j} \begin{vmatrix}
+                            a_{11}     & \cdots & a_{1, j-1}   & a_{1, j+1}   & \cdots & a_{1n}     & 0      \\
+                            \vdots     &        &              &              &        &            & \vdots \\
+                            a_{i-1, 1} & \cdots & a_{i-1, j-1} & a_{i-1, j+1} & \cdots & a_{i-1, n} & 0      \\
+                            a_{i+1, 1} & \cdots & a_{i+1, j-1} & a_{i+1, j+1} & \cdots & a_{i+1, n} & 0      \\
+                            \vdots     &        &              &              &        &            & \vdots \\
+                            a_{n1}     & \cdots & a_{n, j-1}   & a_{n, j+1}   & \cdots & a_{nn}     & 0      \\
+                            a_{i1}     & \cdots & a_{i, j-1}   & a_{i, j+1}   & \cdots & a_{in}     & a_{ij}
+                        \end{vmatrix} = \begin{vmatrix}
+                            A_1         & 0      \\
+                            \alpha_{ij} & a_{ij}
+                        \end{vmatrix}.
+                    \]
+
+                    根据引理，我们有
+                    \[
+                        D_i = (-1)^{2n-i-j} a_{ij} |A_1| = (-1)^{i+j} a_{ij} M_{ij} = a_{ij} A_{ij}.
+                    \]
+
+                    由此可得行列式的递推式定义：
+                    \[
+                        D = \sum_{i=1}^n D_i = \sum_{i=1}^n a_{ij} A_{ij}.
+                    \]
+
+                \item 递归式定义 $\implies$ 公理化定义：
+                    \begin{enumerate}
+                        \item （线性性）直接将公理化定义用递归式对第$i$列展开：
+                            \begin{align*}
+                                    & D(\alpha_1,\ldots,\lambda\alpha_{i}+\mu\beta_i,\ldots,\alpha_n)                                      \\
+                                ={} & \sum_{k=1}^{n}(\lambda a_{ki}+\mu b_{ki})A_{ki}                                                      \\
+                                ={} & \lambda \cdot \sum_{k=1}^{n}a_{ki}A_{ki}+\mu \cdot \sum_{k=1}^{n}b_{ki}A_{ki}                        \\
+                                ={} & \lambda D(\alpha_1,\ldots,\alpha_{i},\ldots,\alpha_n)+\mu D(\alpha_1,\ldots,\beta_i,\ldots,\alpha_n),
+                            \end{align*}
+                            则线性性得证.
+
+                        \item （反对称性）使用数学归纳法证明. 显然，$D(\alpha_1,\alpha_2)=-D(\alpha_2,\alpha_1)$，然后做出归纳假设：对于任意正整数$i,j$，$1 \leqslant i, j \leqslant n - 1$且$i \neq j$，有：
+                            \[ D(\alpha_1,\ldots,\alpha_i,\ldots,\alpha_j,\ldots,\alpha_{n-1})=-D(\alpha_1,\ldots,\alpha_j,\ldots,\alpha_i,\ldots,\alpha_{n-1}). \]
+                            由此做出递推，对交换前后的行列式的首行做展开：
+                            \begin{gather*}
+                                D(\alpha_1,\ldots,\alpha_{i},\ldots,\alpha_{j},\ldots,\alpha_n)
+                                 =\sum_{k=1}^{n}a_{1k}A_{1k},   \\
+                                D(\alpha_1,\ldots,\alpha_{j},\ldots,\alpha_{i},\ldots,\alpha_n)
+                                 =\sum_{k=1}^{n}a'_{1k}A'_{1k}.
+                            \end{gather*}
+                            其中，除第$i,j$项外，由归纳假设，其余项都满足$a_{1k}=a'_{1k},A_{1k}=-A'_{1k}$，则有$a_{1k}A_{1k}=-a'_{1k}A'_{1k},k\neq i,j$. 因此主要考察$a_{1i}A_{1i}+a_{1j}A_{1j}$与$a'_{1i}A'_{1i}+a'_{1j}A'_{1j}$这两项. 首先有$a'_{1i}=a_{1j},a'_{1j}=a_{1i}$. 然后将$A_{1i}$与$A'_{1j}$两项展开对比：
+                            \begin{align*}
+                                A_{1i}  & =(-1)^{1+i} D(\beta_{1},\ldots,\beta_{i-1},\beta_{i+1},\ldots,\beta_{j},\ldots,\beta_{n}),                             \\
+                                A'_{1j} & =(-1)^{1+j} D(\beta_{1},\ldots,\beta_{i-1},\beta_{j},\beta_{i+1},\ldots,\beta_{j-1},\beta_{j+1},\ldots,\beta_{n}).
+                            \end{align*}
+                            式中的$\beta_k$表示原列向量 $\alpha_k$ 去掉首行元素后剩余$n-1$个元素组成的新列向量. 可以发现，$A'_{1j}$向左交换$j-(i+1)$次后与$A_{1i}$是绝对值一致的. 则根据归纳假设，有$(-1)^{j-(i+1)}A'_{1j}=(-1)^{1+j-(1+i)}A_{1i}$，即有$A'_{1j}=-A_{1i}$，所以$a_{1i}A_{1i}+a_{1j}A_{1j}=-(a'_{1j}A'_{1j}+a'_{1i}A'_{1i})$. 综上可证：
+                            \[ D(\alpha_1,\ldots,\alpha_{i},\ldots,\alpha_{j},\ldots,\alpha_n)=D(\alpha_1,\ldots,\alpha_{j},\ldots,\alpha_{i},\ldots,\alpha_n). \]
+
+                        \item （规范性）
+                            \[
+                                |E_n| = \begin{vmatrix}
+                                    E_{n-1}    & \mathbf{0} \\
+                                    \mathbf{0} & 1
+                                \end{vmatrix} = |E_{n-1}| = \cdots = |E_1| = 1.
+                            \]
+                    \end{enumerate}
+
+                \item 公理化定义 $\implies$ 逆序数定义：见本章``逆序数定义''部分的推导.
+
+                \item 逆序数定义 $\implies$ 公理化定义：
+                    \begin{enumerate}
+                        \item （线性性）使用逆序数定义对行列式进行展开：
+                            \begin{align*}
+                                & D(\alpha_1, \ldots , \lambda\alpha_i + \mu\beta_i, \ldots, \alpha_n) \\
+                                ={} & \sum_{(k_1, k_2, \ldots, k_n) \in S_n} (-1)^{\varepsilon} a_{k_1 1} \cdots a_{k_{i-1},i-1} (\lambda a_{k_i i} + \mu b_{k_i i}) a_{k_{i+1},i+1} \cdots a_{k_n n} \\
+                                ={} & \lambda \left(\sum_{(k_1, k_2, \ldots, k_n) \in S_n} (-1)^{\varepsilon} a_{k_1 1} \cdots a_{k_{i-1},i-1} a_{k_i i} a_{k_{i+1},i+1} \cdots a_{k_n n} \right) + \\
+                                 {} & \mu \left(\sum_{(k_1, k_2, \ldots, k_n) \in S_n} (-1)^{\varepsilon} a_{k_1 1} \cdots a_{k_{i-1},i-1} b_{k_i i} \cdots a_{k_n n}\right) \\
+                                ={} & \lambda D(\alpha_1, \ldots, \alpha_i, \ldots, \alpha_n) + \mu D(\alpha_1, \ldots, \beta_i, \ldots, \alpha_n),
+                            \end{align*}
+                            其中 $\varepsilon = \tau(k_1, k_2, \ldots, k_n)$ 表示排列 $(k_1, k_2, \ldots, k_n)$ 的逆序数.
+
+                        \item （反对称性）对于 $D(\alpha_1, \ldots, \alpha_i, \ldots, \alpha_j, \ldots, \alpha_n)$ 逆序数定义展开式中的任意一项
+                            \[
+                                (-1)^{\tau(k_1, \ldots, k_i, \ldots, k_j, \ldots, k_n)} a_{k_1 1} \cdots a_{k_i i} \cdots a_{k_j j} \cdots a_{k_n n},
+                            \]
+
+                            其可以对应 $D(\alpha_1, \ldots, \alpha_j, \ldots, \alpha_i, \ldots, \alpha_n)$ 逆序数定义展开式中的一项
+                            \[
+                                (-1)^{\tau(k_1, \ldots, k_j, \ldots, k_i, \ldots, k_n)} a_{k_1 1} \cdots a_{k_j j} \cdots a_{k_i i} \cdots a_{k_n n}.
+                            \]
+
+                            而排列 $(k_1, \ldots, k_i, \ldots, k_j, \ldots, k_n)$ 与 $(k_1, \ldots, k_j, \ldots, k_i, \ldots, k_n)$ 的奇偶性必定相反，故以上两个对应项为相反数，因此有
+                            \[
+                                D(\alpha_1, \ldots, \alpha_j, \ldots, \alpha_i, \ldots, \alpha_n) = -D(\alpha_1, \ldots, \alpha_i, \ldots, \alpha_j, \ldots, \alpha_n).
+                            \]
+
+                        \item （规范性）$E_n$ 的逆序数定义展开式中只有一项
+                            \[
+                                (-1)^{\tau(1, 2, \ldots, n)} a_{11} a_{22} \cdots a_{nn}
+                            \]
+                            不为零，故 $|E_n| = 1$.
+                    \end{enumerate}
+            \end{enumerate}
+        \end{answer}
 
         \item 设$\alpha_1,\alpha_2,\alpha_3$为三维列向量，令$A=(\alpha_1,\alpha_2,\alpha_3)$，且$|A|=2$，求$|\alpha_1+\alpha_2+\alpha_3,\alpha_1+3\alpha_2+9\alpha_3,\alpha_1+4\alpha_2+16\alpha_3|$.
+        \begin{answer}
+            使用倍加列变换的性质，可得$|\alpha_1+\alpha_2+\alpha_3,\alpha_1+3\alpha_2+9\alpha_3,\alpha_1+4\alpha_2+16\alpha_3|=6|\alpha_1,\alpha_2,\alpha_3|=12$.
+        \end{answer}
 
         \item 求证以下命题：
         \begin{enumerate}
@@ -1909,12 +2052,64 @@
 
             \item 若$A$是$n$阶可逆对称矩阵，$B$是$n$阶反对称矩阵，则当$n$为奇数时，齐次线性方程组$(AB)X=O$有非零解.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 首先由反对称矩阵的性质，有$A^T=-A$，其次由矩阵与行列式的性质，可得$|A^T|=|A|$，则可推出$|A|=|-A|=(-1)^n|A|$，又n为奇数，故$|A|=0$，矩阵$A$不可逆.
+
+                \item 只需证明$AB$的秩小于$n$，即$|AB|=0$即可. $B$是奇数阶反对称矩阵，$|B|=0$,则$|AB|=|A||B|=0$得证.
+            \end{enumerate}
+        \end{answer}
 
         \item 设$A$、$B$分别为$m$、$n$阶可逆矩阵，且$|A|=a$，$|B|=b$，求$\begin{pmatrix}
                 A & O \\ O & B
             \end{pmatrix}^*$和$\begin{pmatrix}
                 O & A \\ B & O
             \end{pmatrix}^*$.
+        \begin{answer}
+            根据伴随矩阵的性质，$\begin{pmatrix}
+                A & O \\ O & B
+            \end{pmatrix}^* = \begin{vmatrix}
+                A & O \\ O & B
+            \end{vmatrix} \cdot \begin{pmatrix}
+                A & O \\ O & B
+            \end{pmatrix}^{-1}$. 其中，对$\begin{vmatrix}
+                A & O \\ O & B
+            \end{vmatrix}$做递归式展开，有$\begin{vmatrix}
+                A & O \\ O & B
+            \end{vmatrix}=\displaystyle\sum_{k=1}^{m}(-1)^{1+k}a_{1k}\begin{vmatrix}
+                M_{1k} & O \\ O & B
+            \end{vmatrix}$，依此逐次展开可得$\begin{vmatrix}
+                A & O \\ O & B
+            \end{vmatrix}=|A||B|=ab$. 又$ab\begin{pmatrix}
+                A & O \\ O & B
+            \end{pmatrix}^{-1}=ab\begin{pmatrix}
+                A^{-1} & O \\ O & B^{-1}
+            \end{pmatrix}=\begin{pmatrix}
+                b\cdot aA^{-1} & O \\ O & a\cdot bB^{-1}
+            \end{pmatrix}$，最终可得$\begin{pmatrix}
+                A & O \\ O & B
+            \end{pmatrix}^* = \begin{pmatrix}
+                bA^* & O \\ O & aB^*
+            \end{pmatrix}$.
+
+            与前一个式子的展开类似，$\begin{pmatrix}
+                    O & A \\ B & O
+                \end{pmatrix}^*=\begin{vmatrix}
+                    O & A \\ B & O
+                \end{vmatrix}\cdot \begin{pmatrix}
+                    O & A \\ B & O
+                \end{pmatrix}^{-1}$，其中对前一步推导做少量修正后可得$\begin{vmatrix}
+                    O & A \\ B & O
+                \end{vmatrix}=(-1)^{mn}|A||B|=(-1)^{mn}ab$,则$(-1)^{mn}ab\begin{pmatrix}
+                    O & A \\ B & O
+                \end{pmatrix}^{-1}=(-1)^{mn}\begin{pmatrix}
+                    O & a\cdot bB^{-1} \\ b\cdot aA^{-1} & O
+                \end{pmatrix}$，最终可得$\begin{pmatrix}
+                    O & A \\ B & O
+                \end{pmatrix}^*=(-1)^{mn}\begin{pmatrix}
+                    O & aB^* \\ bA^* & O
+                \end{pmatrix}$.
+        \end{answer}
 
         \item 证明：
         \begin{enumerate}
@@ -1922,14 +2117,51 @@
 
             \item 若$A$为对称矩阵，则$A^*$也为对称矩阵；$A$为反对称矩阵，则$A^*$为偶数阶时也为反对称矩阵，奇数阶时为对称矩阵.
         \end{enumerate}
+        \begin{answer}
+            证明；\begin{enumerate}
+                \item 对正整数$k$，有$(A^k)^*=(A^*)^k$. 从而若$A^m=A$，则$(A^*)^m=(A^m)^*=A^*$. 即$A$是幂等矩阵，则$A^*$也是幂等矩阵. 同样，若$A^m=0$，则$(A^*)^m=(A^m)^*=0$. 即$A$是幂零矩阵，则$A^*$也是幂零矩阵.
+
+                \item $(A^*)^T=(A^T)^*=A^*$. 从而若$A$是对称矩阵，则$A^*$也是对称矩阵$. (A^*)^T=(A^T)^*=(-A)^*=(-1)^{n-1}A^*$. 从而若$A^*$为偶数阶时也为反对称矩阵，奇数阶时为对称矩阵.
+            \end{enumerate}
+        \end{answer}
 
         \item 证明：上（下）三角矩阵的伴随矩阵是上（下）三角矩阵（对角矩阵为特例）.
+        \begin{answer}
+            对于上三角矩阵，只需看其伴随矩阵的下半部分元素，即$A_{ij},j>i$. 对这些代数余子式，要么有一整行或整列为零，要么对角线存在零元素，则这些余子式均为零，伴随矩阵是上三角矩阵.\par 或者使用另法，当$A$是可逆矩阵，即$A$对角线元素不为零，则$A^*=|A|\cdot A^{-1}$，其中$A^{-1}$也是上三角矩阵，因此伴随矩阵$A^*$是上三角矩阵.
+        \end{answer}
 
         \item 设$A$为$n$阶方阵，证明：若$|A|=0$，则$A$中任意两行（列）对应元素的代数余子式成比例.
+        \begin{answer}
+            $|A|=0$，则$r(A)<n$，故$r(A^*)=\begin{cases}
+                1, & r(A)=n-1 \\
+                0, & r(A)<n-1
+            \end{cases}$. 当$r(A^*)=0$时，答案显然成立；当$r(A^*)=1$时，由矩阵秩的定义，任意两行（列）必成比例，否则秩大于1，矛盾. 综上，原题得证.
+        \end{answer}
 
         \item 设向量$\alpha_1,\alpha_2,\alpha_3$线性无关，讨论向量$\alpha_1-\alpha_2-2\alpha_3,\ 2\alpha_1+\alpha_2-\alpha_3,\ 3\alpha_1+\alpha_2+2\alpha_3$的线性相关性.
+        \begin{answer}
+            $(\alpha_1-\alpha_2-2\alpha_3,2\alpha_1+\alpha_2-\alpha_3,3\alpha_1+\alpha_2+2\alpha_3)=(\alpha_1,\alpha_2,\alpha_3)\begin{pmatrix}
+                1 & 2 & 3 \\ -1 & 1 & 1 \\ -2 & -1 & 2
+            \end{pmatrix}$，又$\begin{vmatrix}
+                1 & 2 & 3 \\ -1 & 1 & 1 \\ -2 & -1 & 2
+            \end{vmatrix}=12\neq 0$，因此该矩阵可逆，则$(\alpha_1-\alpha_2-2\alpha_3,2\alpha_1+\alpha_2-\alpha_3,3\alpha_1+\alpha_2+2\alpha_3)$与$(\alpha_1,\alpha_2,\alpha_3)$秩相等，因此这三个向量线性无关.
+        \end{answer}
 
         \item 设$W=\spa(\alpha_1,\alpha_2)$是$\mathbf{R}^4$的一个子空间，其中$\alpha_1=(1,2,1,-1)^\mathrm{T}$，$\alpha_2=(1,4,-1,-1)^\mathrm{T}$，试将$\alpha_1,\alpha_2$扩充为$\mathbf{R}^4$的基.
+        \begin{answer}
+            只要取$\alpha_3,\alpha_4 \in \mathbf{R}^4$，使得$D(\alpha_1,\alpha_2,\alpha_3,\alpha_4) \neq 0$即可. 易得$\begin{vmatrix}
+                1  & 1  & 0 & 0 \\
+                2  & 4  & 0 & 0 \\
+                1  & -1 & 1 & 0 \\
+                -1 & 1  & 0 & 1
+            \end{vmatrix}=\begin{vmatrix}
+                1 & 1 \\
+                2 & 4
+            \end{vmatrix} \cdot \begin{vmatrix}
+                1 & 0 \\
+                0 & 1
+            \end{vmatrix}=2 \neq 0$. 于是可取$\alpha_3=(0,0,1,0)^T,\alpha_4=(0,0,0,1)^T$，能使得${\alpha_1,\alpha_2,\alpha_3,\alpha_4}$为$\mathbf{R}^4$的一组基.
+        \end{answer}
 
         \item $ D_n=\begin{vmatrix}
                 1      & 2      & 3      & 4      & \cdots & n-1    & n      \\
@@ -1940,6 +2172,39 @@
                 x      & x      & x      & x      & \cdots & 1      & 2      \\
                 x      & x      & x      & x      & \cdots & x      & 1      \\
             \end{vmatrix}$（提示：考虑滚动消去法）.
+        \begin{answer}
+            考虑滚动消去法，每行减下一行，得
+            \[ \begin{vmatrix}
+                    1-x    & 1      & 1      & 1      & \ldots & 1      & 1      \\
+                    0      & 1-x    & 1      & 1      & \ldots & 1      & 1      \\
+                    0      & 0      & 1-x    & 1      & \ldots & 1      & 1      \\
+                    0      & 0      & 0      & 1-x    & \ldots & 1      & 1      \\
+                    \vdots & \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
+                    0      & 0      & 0      & 0      & \ldots & 1-x    & 1      \\
+                    x      & x      & x      & x      & \ldots & x      & 1      \\
+                \end{vmatrix}. \]
+            第一行乘$(-x)$到第$n$行，得
+            \[\begin{vmatrix}
+                    1-x    & 1      & 1      & 1      & \ldots & 1      & 1      \\
+                    0      & 1-x    & 1      & 1      & \ldots & 1      & 1      \\
+                    0      & 0      & 1-x    & 1      & \ldots & 1      & 1      \\
+                    0      & 0      & 0      & 1-x    & \ldots & 1      & 1      \\
+                    \vdots & \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
+                    0      & 0      & 0      & 0      & \ldots & 1-x    & 1      \\
+                    x^2    & 0      & 0      & 0      & \ldots & 0      & 1-x    \\
+                \end{vmatrix}.\]
+            按第$n$行展开，得$D_n=(1-x)^n+(-1)^{n+1}x^2T_{n-1}$，其中
+            \[T_{n-1}=\begin{vmatrix}
+                    1      & 1      & 1      & \ldots & 1      & 1      \\
+                    1-x    & 1      & 1      & \ldots & 1      & 1      \\
+                    0      & 1-x    & 1      & \ldots & 1      & 1      \\
+                    \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
+                    0      & 0      & 0      & \ldots & 1      & 1      \\
+                    0      & 0      & 0      & \ldots & 1-x    & 1      \\
+                \end{vmatrix}.\]
+            按第$n-1$行展开$T_{n-1}$，有$T_{n-1}=T_{n-2}+(-1)(1-x)T_{n-2}=xT_{n-2}$. 由$T_2=\begin{vmatrix}
+                    1&1\\1-x&1\end{vmatrix}=x$，递推得$T_{n-1}=x^{n-2}$. 代入可解得$D_n=(1-x)^n-(-x)^n$.
+        \end{answer}
 
         \item $ D_n=\begin{vmatrix}
                 a_1 & b_1 &     &        &         \\
@@ -1948,6 +2213,9 @@
                     &     &     & \ddots & b_{n-1} \\
                 b_n &     &     &        & a_n
             \end{vmatrix}$.
+        \begin{answer}
+            按第一列展开，得$D_n=\displaystyle\prod_{i=1}^na_i+(-1)^{n+1}\prod_{i=1}^nb_i$.
+        \end{answer}
 
         \item $D_n=\begin{vmatrix}
                 a+b & ab  &        &     &     \\
@@ -1956,8 +2224,97 @@
                     &     & \ddots & a+b & ab  \\
                     &     &        & 1   & a+b \\
             \end{vmatrix}$.
+        \begin{answer}
+            按第一列展开，得
+            \begin{align*}
+                D_{n} & =(a+b) D_{n-1}-\begin{vmatrix}
+                                            a b    & 0      & 0      & 0   & \cdots & 0      & 0      \\
+                                            1      & a+b    & a b    & 0   & \cdots & 0      & 0      \\
+                                            0      & 1      & a+b    & a b & \cdots & 0      & 0      \\
+                                            \vdots & \vdots & \vdots & a+b & \ddots & \vdots & \vdots \\
+                                            0      & 0      & 0      & 0   & \cdots & a+b    & a b    \\
+                                            0      & 0      & 0      & 0   & \cdots & 1      & a+b
+                                        \end{vmatrix} \\
+                        & =(a+b) D_{n-1}-a b D_{n-2}.
+            \end{align*}
+            \begin{enumerate}
+                \item 方法一：特征方程法. 有特征方程$r^2-(a+b)r+ab=(r-a)(r-b)=0$，先考虑$a\neq b$，则$D_n=C_1a^n+C_2b^n$，$D_{1}=a+b$，$D_{2}=a^{2}+a b+b^{2}$，则有
+                        \[\begin{cases}
+                                C_1a+C_2b=a+b \\
+                                C_1a^2+C_2b^2=a^2+ab+b^2
+                            \end{cases},\]
+                        考虑Cramer法则，首先判断系数行列式$\begin{vmatrix}
+                                a   & b   \\
+                                a^2 & b^2
+                            \end{vmatrix}=ab(b-a)$，若$a=b=0$，原行列式为0；若$a=0,b\neq 0$，则有$C_2=1$，$D_n=b^n$；同理若$a=0,b\neq 0$，$D_n=a^n$. 考虑$a\neq 0,b\neq 0$，则系数行列式非0，根据Cramer法则可以解得
+                        \[C_1=\frac{\begin{vmatrix}
+                                    a+b        & b   \\
+                                    a^2+ab+b^2 & b^2
+                                \end{vmatrix}}{ab(b-a)}=\frac{a}{a-b},\quad
+                            C_2=\frac{\begin{vmatrix}
+                                    a   & a+b        \\
+                                    a^2 & a^2+ab+b^2
+                                \end{vmatrix}}{ab(b-a)}=-\frac{b}{a-b}.\]
+                        故$D_n=\displaystyle\frac{a^{n+1}-b^{n+1}}{a-b}$. 考虑到$a$或$b$为0时也符合该公式，故合并为同一公式. 再考虑$a=b$，则$D_n=(C_1+C_2n)a^n$，有方程
+                        \[\begin{cases}
+                                (C_1+C_2)a=2a \\
+                                (C_1+2C_2)a^2=3a^2
+                            \end{cases},\]
+                        $a=0$，则$D_n=0$；$a\neq 0$，可以解得$C_1=C_2=1$，有$D_n=(n+1)a^n$. 考虑到$a=0$时$D_n$也符合该式，故合并. 综上有
+                        \[D_n=\begin{cases}
+                                \displaystyle\frac{a^{n+1}-b^{n+1}}{a-b}, & a\neq b \\
+                                (n+1)a^n,                                 & a=b
+                            \end{cases}.\]
+
+                \item 方法二：递推式变形法. 递推式变形, 得
+                        \[\mathrm{D}_{n}-a D_{n-1}=b\left(D_{n-1}-a D_{n-2}\right),\]
+                        由于 $D_{1}=a+b, D_{2}=a^{2}+a b+b^{2}$,从而利用上述递推公式得
+                        \begin{align*}
+                            \mathrm{D}_{n}-a D_{n-1} & =b\left(D_{n-1}-a D_{n-2}\right)                \\
+                                                    & =b^{2}\left(D_{n-2}-a D_{n-3}\right)            \\
+                                                    & =\cdots=b^{n-2}\left(D_{2}-a D_{1}\right)=b^{n}.
+                        \end{align*}
+                        故\begin{align*}
+                            D_{n} & =a D_{n-1}+b^{n}=a\left(a D_{n-2}+b^{n-1}\right)+b^{n}     \\
+                                  & =\cdots=a^{n-1} D_{1}+a^{n-2} b^{2}+\cdots+a b^{n-1}+b^{n} \\
+                                  & =a^{n}+a^{n-1} b+\cdots+a b^{n-1}+b^{n}                    \\
+                                  & =\begin{cases}
+                                        \displaystyle\frac{a^{n+1}-b^{n+1}}{a-b}, & a\neq b \\
+                                        (n+1)a^n,                                 & a=b
+                                     \end{cases}.
+                        \end{align*}
+            \end{enumerate}
+        \end{answer}
 
         \item 用递推法解\autoref{ex:递推法}.
+        \begin{answer}
+            与数归法相同，先得到 $D_n$ 的递推式：
+            \[
+                D_n - 2 \cos \beta D_{n-1} + D_{n-2} = 0,
+            \]
+            其中 $D_1 = \cos \beta, \enspace D_2 = \cos 2\beta$.
+
+            现求其特征方程
+            \[
+                \lambda^2 - 2 \lambda \cos \beta + 1 = 0
+            \]
+            的根，有
+            \[
+                \lambda = 2 \cos \beta \pm 2 \mathrm{i} \sin \beta.
+            \]
+            故令
+            \[
+                D_n = C_1 \cos n\beta + C_2 \sin n\beta,
+            \]
+            代入初值，有
+            \[
+                \begin{cases}
+                    C_1 \cos \beta + C_2 \sin \beta = \cos \beta, \\
+                    C_1 \cos 2\beta + C_2 \sin 2\beta = \cos 2\beta.
+                \end{cases}
+            \]
+            易知 $C_1 = 1, C_2 = 0$ 为其解，故 $D_n = \cos n\beta$.
+        \end{answer}
 
         \item 解行列式 $ \begin{vmatrix}
                 a^{2} & (a+1)^{2} & (a+2)^{2} & (a+3)^{2} \\
@@ -1965,6 +2322,39 @@
                 c^{2} & (c+1)^{2} & (c+2)^{2} & (c+3)^{2} \\
                 d^{2} & (d+1)^{2} & (d+2)^{2} & (d+3)^{2}
             \end{vmatrix} $.
+        \begin{answer}
+            \begin{enumerate}
+                \item 方法一：慢慢消去.
+                      \begin{align*}
+                          \begin{vmatrix}
+                              a^{2} & (a+1)^{2} & (a+2)^{2} & (a+3)^{2} \\
+                              b^{2} & (b+1)^{2} & (b+2)^{2} & (b+3)^{2} \\
+                              c^{2} & (c+1)^{2} & (c+2)^{2} & (c+3)^{2} \\
+                              d^{2} & (d+1)^{2} & (d+2)^{2} & (d+3)^{2}
+                          \end{vmatrix}
+                           & = \begin{vmatrix}
+                                   a^{2} & 2a+1 & 4a+4 & 6a+9 \\
+                                   b^{2} & 2b+1 & 4b+4 & 6b+9 \\
+                                   c^{2} & 2c+1 & 4c+4 & 6c+9 \\
+                                   d^{2} & 2d+1 & 4d+4 & 6d+9
+                               \end{vmatrix} \\
+                           & = \begin{vmatrix}
+                                   a^{2} & 2a+1 & 4a+4 & 4 \\
+                                   b^{2} & 2b+1 & 4b+4 & 4 \\
+                                   c^{2} & 2c+1 & 4c+4 & 4 \\
+                                   d^{2} & 2d+1 & 4d+4 & 4
+                               \end{vmatrix}    \\
+                           & = 4\begin{vmatrix}
+                                    a^{2} & 2a & 4a & 1 \\
+                                    b^{2} & 2b & 4b & 1 \\
+                                    c^{2} & 2c & 4c & 1 \\
+                                    d^{2} & 2d & 4d & 1
+                                \end{vmatrix}=0.
+                      \end{align*}
+
+                \item 关注到行列式中只有$(a^2, b^2, c^2, d^2)^\mathrm{T}, (a, b, c, d)^\mathrm{T}$和$(1, 1, 1, 1)^\mathrm{T}$三个线性无关列向量，则一眼看出线性相关. 因此设原行列式为$|\alpha_1, \alpha_2, \alpha_3, \alpha_4|$，有$\alpha_4=\alpha_1-3\alpha_2+3\alpha_3$，因此原行列式值为0.
+            \end{enumerate}
+        \end{answer}
 
         \item 设
         \[ D=\begin{vmatrix}
@@ -1978,6 +2368,63 @@
 
             \item 硬拆$D$为$2^n$个行列式，计算出结果.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item \begin{align*}
+                          D_n & =\begin{vmatrix}
+                                     D_{n-1} & a   \\
+                                     b       & a_n
+                                 \end{vmatrix},a=(0, \ldots, 0, -a_{n-1})^\mathrm{T}, b=(1, \ldots, 1) \\
+                              & =a_nD_{n-1}+a_{n-1}\begin{vmatrix}
+                                                       D_{n-2} & 1_{n-2} \\
+                                                       1_{n-2} & 1
+                                                   \end{vmatrix}
+                          \quad \text{($1_{n-2}$表示由$(n-2)$个1构成的行/列向量)}                      \\
+                              & =a_nD_{n-1}+a_{n-1}
+                          \begin{vmatrix}
+                              a_1    & 0      & 0      & \ldots & 0       & 1      \\
+                              0      & a_2    & 0      & \ldots & 0       & 1      \\
+                              0      & 0      & a_3    & \ldots & 0       & 1      \\
+                              \vdots & \vdots & \vdots & \ddots & \vdots  & \vdots \\
+                              0      & 0      & 0      & \ldots & a_{n-2} & 1      \\
+                              0      & 0      & 0      & \ldots & 0       & 1      \\
+                          \end{vmatrix} \quad \text{($1-n$列用第$n$列减)}                         \\
+                              & =a_nD_{n-1}+\prod_{i=1}^{n-1}a_i.
+                      \end{align*}
+                      递推可得$\displaystyle D_n=\left(\prod_{k=1}^na_k\right)
+                          \left(1+\sum_{i=1}^n\frac{1}{a_i}\right)$.
+
+                \item 将 1 写成 $1+0$, 将 $D$ 硬拆成 $2^{n}$ 个行列式, 只有如下的 $n+1$ 个行列式非 0：
+                      \begin{align*}
+                          D_n = & \begin{vmatrix}
+                                      1      &       &        &       \\
+                                      1      & a_{2} &        &       \\
+                                      \vdots &       & \ddots &       \\
+                                      1      &       &        & a_{n}
+                                  \end{vmatrix}
+                          +\begin{vmatrix}
+                               a_{1} & 1      &                \\
+                                     & 1      &                \\
+                                     & \vdots & \ddots &       \\
+                                     & 1      &        & a_{n}
+                           \end{vmatrix}+\cdots+                    \\
+                                & \begin{vmatrix}
+                                      a_{1} &       &        & 1      \\
+                                            & a_{2} &        & 1      \\
+                                            &       & \ddots & \vdots \\
+                                            &       &        & 1
+                                  \end{vmatrix}
+                          +\begin{vmatrix}
+                               a_{1} &                      \\
+                                     & a_{2} &              \\
+                                     &       & \ddots &     \\
+                                     &       &        & a_n
+                           \end{vmatrix}                       \\
+                          =     & \left(\prod_{k=1}^{n} a_{k}+\frac{1}{a_{2}}
+                          \prod_{k=1}^{n} a_{k}\right)\left(1+\sum_{i=1}^{n} \frac{1}{a_{i}}\right).
+                      \end{align*}
+            \end{enumerate}
+        \end{answer}
 
         \item 解行列式
         \begin{enumerate}
@@ -1996,8 +2443,140 @@
                           n      & 1      & \cdots & n-2    & n-1
                       \end{vmatrix}$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 行列式中2比较多，用全是2的第二行去消，然后按第2行展开.
+                      \[D=\begin{vmatrix}
+                              -1     & 0      & \cdots & 0      & 0      \\
+                              2      & 2      & \cdots & 2      & 2      \\
+                              \vdots & \vdots & \ddots & \vdots & \vdots \\
+                              0      & 0      & \cdots & n-3    & 0      \\
+                              0      & 0      & \cdots & 0      & n-2
+                          \end{vmatrix}=2\cdot(-1)\cdot(n-2)!=-2(n-2)!.\]
+
+                \item \begin{enumerate}
+                          \item 方法一：考虑滚动消去法，有
+                                \begin{align*}
+                                    D & =\begin{vmatrix}
+                                             1      & 2      & 3      & \cdots & n-1    & n      \\
+                                             1      & 1      & 1      & \cdots & 1      & 1-n    \\
+                                             1      & 1      & 1      & \cdots & 1-n    & 1      \\
+                                             \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
+                                             1      & 1      & 1-n    & \cdots & 1      & 1      \\
+                                             1      & 1-n    & 1      & \cdots & 1      & 1
+                                         \end{vmatrix}                                    \\&=\begin{vmatrix}
+                                        0      & n+1    & 2      & \cdots & n-2    & n-1    \\
+                                        0      & n      & 0      & \cdots & 0      & -n     \\
+                                        0      & n      & 0      & \cdots & -n     & 0      \\
+                                        \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
+                                        0      & n      & -n     & \cdots & 0      & 0      \\
+                                        1      & 1-n    & 1      & \cdots & 1      & 1
+                                    \end{vmatrix}\\
+                                      & =(-1)^{n+1}\begin{vmatrix}
+                                                       n+1    & 2      & \cdots & n-2    & n-1    \\
+                                                       n      & 0      & \cdots & 0      & -n     \\
+                                                       n      & 0      & \cdots & -n     & 0      \\
+                                                       \vdots & \vdots & \ddots & \vdots & \vdots \\
+                                                       n      & -n     & \cdots & 0      & 0
+                                                   \end{vmatrix}                                   \\
+                                      & =(-1)^{n+1}(-1)^{\frac{(n-2)(n-3)}{2}}
+                                    \begin{vmatrix}
+                                        n+1    & n-1    & \cdots & 3      & 2      \\
+                                        n      & -n     & \cdots & 0      & 0      \\
+                                        n      & 0      & \cdots & 0      & 0      \\
+                                        \vdots & \vdots & \ddots & \vdots & \vdots \\
+                                        n      & 0      & \cdots & 0      & -n
+                                    \end{vmatrix}                                                  \\
+                                      & =(-1)^{\frac{n^2-3n+8}{2}}\begin{vmatrix}
+                                                                      \frac{n(n+1)}{2} & n-1    & \cdots & 3      & 2      \\
+                                                                      0                & -n     & \cdots & 0      & 0      \\
+                                                                      0                & 0      & \cdots & 0      & 0      \\
+                                                                      \vdots           & \vdots & \ddots & \vdots & \vdots \\
+                                                                      0                & 0      & \cdots & 0      & -n
+                                                                  \end{vmatrix}=(-1)^{\frac{n^2-n+12}{2}}\frac{n^{n-1}(n+1)}{2}.
+                                \end{align*}
+
+                          \item 方法二：考虑连加法. 将第 $2,3, \ldots, n$ 列都加到第 1 列, 提出公因子 $\dfrac{1}{2} n(n+1)$, 再依次将第 $n-1$ 行乘 $(-1)$ 加到第 $n$ 行, $\cdots$, 第 2 行乘 $(-1)$ 加到第 3 行, 第 1 行乘 $(-1)$ 加到第 2 行, 然后对第 1 列展开, 得到一个 $n-1$ 阶行列式, 它的副对角元为 $1-$ $n$, 其余元素均为 1 . 再把它的各列加到第 1 列, 并把它的第 1 行乘 $(-1)$ 加到其余各行, 得
+                                \begin{align*}
+                                    D & =\frac{n(n+1)}{2}\begin{vmatrix}
+                                                             1      & 2      & \cdots & n-1    & n      \\
+                                                             1      & 3      & \cdots & n      & 1      \\
+                                                             1      & 4      & \cdots & 1      & 2      \\
+                                                             \vdots & \vdots & \ddots & \vdots & \vdots \\
+                                                             1      & 1      & \cdots & n-2    & n-1
+                                                         \end{vmatrix} \\
+                                      & =\frac{n(n+1)}{2}\begin{vmatrix}
+                                                             1      & 2      & 3      & \cdots & n      \\
+                                                             0      & 1      & 1      & \cdots & 1-n    \\
+                                                             \vdots & \vdots & \vdots & \ddots & \vdots \\
+                                                             0      & 1      & 1-n    & \cdots & 1      \\
+                                                             0      & 1-n    & 1      & \cdots & 1
+                                                         \end{vmatrix}_{n} \\
+                                      & =\frac{n(n+1)}{2}
+                                    \begin{vmatrix}
+                                        1      & 1      & \cdots & 1      & 1-n \\
+                                        \vdots & \vdots & \ddots & \vdots & 1   \\
+                                        1      & 1-n    & \cdots & 1      & 1   \\
+                                        1-n    & 1      & \cdots & 1      & 1
+                                    \end{vmatrix}                         \\
+                                      & =\frac{n(n+1)}{2}\begin{vmatrix}
+                                                             -1     & 1      & \cdots & 1      & 1-n    \\
+                                                             0      & 0      & \cdots & -n     & n      \\
+                                                             \vdots & \vdots & \ddots & \vdots & \vdots \\
+                                                             0      & -n     & \cdots & 0      & n      \\
+                                                             0      & 0      & \cdots & 0      & n
+                                                         \end{vmatrix}_{n-1}
+                                \end{align*}
+                                将上式先对第 1 列展开, 得到一个 $n-2$ 阶行列式, 再将它对最后一行展开, 得
+                                \begin{align*}
+                                    D & =\frac{-n(n+1)}{2} n
+                                    \begin{vmatrix}
+                                        0      & 0      & \cdots & 0      & -n     \\
+                                        0      & 0      & \cdots & -n     & 0      \\
+                                        \vdots & \vdots & \ddots & \vdots & \vdots \\
+                                        0      & -n     & \cdots & 0      & 0      \\
+                                        -n     & 0      & \cdots & 0      & 0
+                                    \end{vmatrix}_{n-3}                      \\
+                                      & =-\frac{n^{2}(n+1)}{2}(-1)^{\frac{(n-3)(n-4)}{2}}(-n)^{n-3} \\
+                                      & =(-1)^{\frac{n(n-1)}{2} }\frac{(n+1) n^{n-1}}{2}.
+                                \end{align*}
+                                事实上，两种方法得到的答案是等价的.
+                      \end{enumerate}
+            \end{enumerate}
+        \end{answer}
 
         \item 记$a_{ij}=|i-j|$，且$A=(a_{ij})_{n\times n}$，计算$A$的行列式.
+        \begin{answer}
+            \begin{enumerate}
+                \item 若 $n=1$，则 $|A| = |0| = 0$；
+
+                \item 若 $n=2$, 则 $|A| = \begin{vmatrix} 0 & -1 \\ 1 & 0 \end{vmatrix} = 1$；
+
+                \item 若 $n>2$，考虑使用滚动消去法：
+                    \begin{align*}
+                        |A| &= \begin{vmatrix}
+                            0      & -1     & -2     & \cdots & -n+1   \\
+                            1      & 0      & -1     & \cdots & -n+2   \\
+                            2      & 1      & 0      & \cdots & -n+3   \\
+                            \vdots & \vdots & \vdots & \ddots & \vdots \\
+                            n-1    & n-2    & n-3    & \cdots & 0
+                        \end{vmatrix} \\
+                        &= \begin{vmatrix}
+                            1 & 1 & \cdots & 1 & -n+1 \\
+                            1 & 1 & \cdots & 1 & -n+2 \\
+                            \vdots & \vdots & \ddots & \vdots & \vdots \\
+                            1 & 1 & \cdots & 1 & 0
+                        \end{vmatrix} \\
+                        &= \begin{vmatrix}
+                            1 & 0 & \cdots & 0 & -n+1 \\
+                            1 & 0 & \cdots & 0 & -n+2 \\
+                            \vdots & \vdots & \ddots & \vdots & \vdots \\
+                            1 & 0 & \cdots & 0 & 0
+                        \end{vmatrix}
+                        = 0.
+                    \end{align*}
+            \end{enumerate}
+        \end{answer}
 
         \item 计算行列式$D=\begin{vmatrix}
                 1 & 0 & 2 & 0 & x   \\
@@ -2006,6 +2585,43 @@
                 0 & 5 & 0 & 3 & 0   \\
                 1 & 0 & 8 & 0 & x^3
             \end{vmatrix}$.
+        \begin{answer}
+            我们可以先构造分块对角矩阵，然后分别处理两个低阶的行列式：
+            \[
+                D = (-1)^{3+3} \begin{vmatrix}
+                    1 & 2 & x   & 0 & 0 \\
+                    1 & 4 & x^2 & 0 & 0 \\
+                    1 & 8 & x^3 & 0 & 0 \\
+                    0 & 0 & 0   & 2 & 1 \\
+                    0 & 0 & 0   & 5 & 3
+                \end{vmatrix} = (-1)^{3+3} \begin{vmatrix}
+                    1 & 2 & x   \\
+                    1 & 4 & x^2 \\
+                    1 & 8 & x^3
+                \end{vmatrix} \begin{vmatrix}
+                    2 & 1 \\
+                    5 & 3
+                \end{vmatrix} = \begin{vmatrix}
+                    1 & 2 & x   \\
+                    1 & 4 & x^2 \\
+                    1 & 8 & x^3
+                \end{vmatrix}.
+            \]
+
+            该行列式可以通过加边法构造范德蒙行列式：
+            \[
+                D = \begin{vmatrix}
+                    1 & 2 & x   \\
+                    1 & 4 & x^2 \\
+                    1 & 8 & x^3
+                \end{vmatrix} = \begin{vmatrix}
+                    1 & 1 & 1 & 1   \\
+                    0 & 1 & 2 & x   \\
+                    0 & 1 & 4 & x^2 \\
+                    0 & 1 & 8 & x^3
+                \end{vmatrix} = 2x(x-1)(x-2).
+            \]
+        \end{answer}
 
     \end{exgroup}
 
@@ -2020,22 +2636,146 @@
 
             \item $M_{41}+M_{42}+M_{43}+M_{44}$.
         \end{enumerate}
+        \begin{answer}
+            这三小问实际上都是对原行列式中的某一行进行了替换进行计算.
+            \begin{enumerate}
+                \item \begin{align*}
+                            A_{21}+A_{22}+A_{23}+A_{24}
+                            & = \begin{vmatrix}
+                                    3 & 0  & 4  & 1 \\
+                                    1 & 1  & 1  & 1 \\
+                                    0 & -7 & 8  & 3 \\
+                                    5 & 3  & -2 & 2
+                                \end{vmatrix}
+                            = \begin{vmatrix}
+                                3 & -3 & 1  & -2 \\
+                                1 & 0  & 0  & 0  \\
+                                0 & -7 & 8  & 3  \\
+                                5 & -2 & -7 & -3
+                            \end{vmatrix}             \\
+                            & = (-1)^{2+1} \begin{vmatrix}
+                                                -3 & 1  & -1 \\
+                                                -7 & 8  & 3  \\
+                                                -2 & -7 & -3
+                                            \end{vmatrix} \\
+                            & = 148.
+                        \end{align*}
+
+                \item \begin{align*}
+                            A_{31}+A_{33}
+                            & = 1A_{31}+0A_{32}+1A_{33}+0A_{34}
+                            = \begin{vmatrix}
+                                3 & 0 & 4  & 1 \\
+                                2 & 3 & 1  & 4 \\
+                                1 & 0 & 1  & 0 \\
+                                5 & 3 & -2 & 2
+                            \end{vmatrix}
+                            = 3 \begin{vmatrix}
+                                    3 & 0 & 4  & 1 \\
+                                    2 & 1 & 1  & 4 \\
+                                    1 & 0 & 1  & 0 \\
+                                    5 & 1 & -2 & 2
+                                \end{vmatrix}                   \\
+                            & = 3 \begin{vmatrix}
+                                    3 & 0 & 1  & 1 \\
+                                    2 & 1 & -1 & 4 \\
+                                    1 & 0 & 0  & 0 \\
+                                    5 & 3 & -7 & 2
+                                \end{vmatrix}
+                            = 3 \cdot (-1)^{3+1} \begin{vmatrix}
+                                                    0 & 1  & 1 \\
+                                                    1 & -1 & 4 \\
+                                                    3 & -7 & 2
+                                                \end{vmatrix}  \\
+                            & = -12.
+                        \end{align*}
+
+                \item \begin{align*}
+                            M_{41}+M_{42}+M_{43}+M_{44}
+                            & = -A_{41}+A_{42}-A_{43}+A_{44}
+                            = \begin{vmatrix}
+                                3  & 0  & 4  & 1 \\
+                                2  & 3  & 1  & 4 \\
+                                0  & -7 & 8  & 3 \\
+                                -1 & 1  & -1 & 1
+                            \end{vmatrix}                     \\
+                            & = \begin{vmatrix}
+                                    3  & 3  & 1  & 4 \\
+                                    2  & 5  & -1 & 6 \\
+                                    0  & -7 & 8  & 3 \\
+                                    -1 & 0  & 0  & 0
+                                \end{vmatrix}
+                            = {-1}^{4+1} \cdot (-1) \begin{vmatrix}
+                                                        3  & 1  & 4 \\
+                                                        5  & -1 & 6 \\
+                                                        -7 & 8  & 3
+                                                    \end{vmatrix} \\
+                            & = -78.
+                        \end{align*}
+            \end{enumerate}
+        \end{answer}
 
         \item 求参数 $a,b$  的值，使得$\begin{vmatrix}1 & 1 & 1 \\ x & y & z \\u & v & w\end{vmatrix}=1,
             \begin{vmatrix}1 & 2 & -5 \\ x & y & z \\u & v & w\end{vmatrix}=2,
             \begin{vmatrix}2 & 3 & b \\ x & y & z \\u & v & w\end{vmatrix}=a$都成立，并求$\begin{vmatrix}x & y & z \\ 1 & -1 & 5 \\u & v & w\end{vmatrix}$.
+        \begin{answer}
+            有问题，之后可能会考虑修改题目，此处略.
+        \end{answer}
 
         \item 设$A,B$为三阶矩阵，且$|A|=3,|B|=2$，且$|A^{-1}+B|=2$，求$|A+B^{-1}|$.
+        \begin{answer}
+            \begin{align*}
+                \lvert A+B^{-1} \rvert ={} & \lvert B^{-1}BA+B^{-1}E \rvert = \lvert B^{-1} \rvert \cdot \lvert BA+E \rvert                  \\
+                ={}                        & \frac{1}{2} \lvert BA+A^{-1}A \rvert = \frac{1}{2} \lvert B+A^{-1} \rvert \cdot \lvert A \rvert \\
+                ={}                        & \frac{3}{2} \lvert A^{-1}+B \rvert = 3.
+            \end{align*}
+        \end{answer}
 
         \item 设$A$为$n$阶正交矩阵，即$AA^\mathrm{T}=A^\mathrm{T}A=E$，且$|A|<0$，证明：$|E+A|=0$.
+        \begin{answer}
+            正交矩阵满足 $AA^{\mathrm{T}} = A^{\mathrm{T}}A = E$，所以 $\lvert AA^{\mathrm{T}} \rvert = \lvert A \rvert^2 = \lvert E \rvert = 1$. 而 $\lvert A \rvert < 0$，所以 $\lvert A \rvert = -1$.
+            \[\lvert E+A \rvert = \lvert AA^{\mathrm{T}}+A \rvert = \lvert A \rvert \cdot \lvert A^{\mathrm{T}}+E \rvert = -\lvert (A+E)^{\mathrm{T}} \rvert = -\lvert E+A \rvert.\]
+            故 $\lvert E+A \rvert = 0$.
+
+            以上两道题都多次运用了 $E = AA^{-1} = A^{-1}A$ 的技巧，请大家留意.
+        \end{answer}
 
         \item 设实方阵$A$的伴随矩阵$A^*=\begin{pmatrix}
                 1 & 0 & 0 \\ 0 & 1 & 0 \\ 1 & 0 & 1
             \end{pmatrix}$，且$|A|>0$，已知矩阵$B$满足$AB=E+3A$，求矩阵$B$.
+        \begin{answer}
+            由 $A$ 为三阶矩阵，可得 $|A|^2 = |A^*| = 1$，而 $|A|>0$，所以 $|A|=1$. $AB=E+3A$ 经变形可得 $A(B-3E) = E$，故有
+            \[
+                B = 3E + A^{-1} = 3E + \frac{A^*}{|A|} = \begin{pmatrix}
+                    4 & 0 & 0 \\ 0 & 4 & 0 \\ 1 & 0 & 4
+                \end{pmatrix}.
+            \]
+        \end{answer}
 
         \item 设$B=\begin{pmatrix}
                 1 & 1 & 1 \\ 0 & 1 & 1 \\ 0 & 0 & 1
             \end{pmatrix}$，矩阵$A$满足方程$BA=B^\mathrm{T}B$，求$|A^*-2E|$.
+        \begin{answer}
+            $|B|=1$，对 $BA=B^\mathrm{T}B$ 两边同时取行列式有
+            \[
+                |B||A| = |B^\mathrm{T}||B| = |B|^2,
+            \]
+            故 $|A| = 1$. 从而有
+            \[
+                A^* = |A|A^{-1} = B^{-1} \left(B^\mathrm{T}\right)^{-1} B.
+            \]
+            $B^{-1} = \begin{pmatrix}
+                1 & 0 & 0 \\ -1 & 1 & 0 \\ 0 & -1 & 1
+            \end{pmatrix}$，于是有
+            \[
+                |A^*-2E| = \lvert B^{-1} \left(B^\mathrm{T}\right)^{-1} B - 2 B^{-1} B \rvert
+                         = \lvert B^{-1} \rvert \lvert \left(B^\mathrm{T}\right)^{-1} - 2E \rvert \lvert B \rvert
+                         = \begin{vmatrix}
+                            -1 & 0 & 0 \\ -1 & -1 & 0 \\ 0 & -1 & -1
+                         \end{vmatrix}
+                         = -1.
+            \]
+        \end{answer}
 
         \item 已知齐次线性方程组
         \[\begin{cases} \begin{aligned}
@@ -2050,8 +2790,27 @@
 
             \item 若$r(A)=n-1$，则方程组的解全是$(M_1,-M_2,\ldots,(-1)^{n-1}M_n)$的倍数.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 由于行列式
+                      \[ D = \begin{vmatrix}
+                              a_{11}     & a_{12}     & a_{13}     & \cdots & a_{1n}     \\
+                              a_{11}     & a_{12}     & a_{13}     & \cdots & a_{1n}     \\
+                              a_{21}     & a_{22}     & a_{23}     & \cdots & a_{2n}     \\
+                              \vdots     & \vdots     & \vdots     & \ddots & \vdots     \\
+                              a_{n-1, 1} & a_{n-1, 2} & a_{n-1, 3} & \cdots & a_{n-1, n}
+                          \end{vmatrix} = 0,\]
+                      而 $M_1, -M_2, \ldots, (-1)^{n-1}M_n$ 恰是 $D$ 的第一行元素的代数余子式，所以将 $D$ 按第一行展开，可知\[a_{11}M_1+a_{12}(-M_2)+\cdots+a_{1n}(-1)^{n-1}M_n=0.\]
+                      而 $D$ 的其他行元素与第一行元素的代数余子式乘积之和为 0，于是结论成立.
+
+                \item 因为 $r(A) = n-1$，所以 $M_1, -M_2, \ldots, (-1)^{n-1}M_n$，不全为 0. 且该方程组解空间维数为 1，$M_1, -M_2, \ldots, (-1)^{n-1}M_n$ 正是该方程组的非零解，结论成立.
+            \end{enumerate}
+        \end{answer}
 
         \item 设$A,B$均为$n$阶矩阵，且$|A|=2,|B|=1$，求$|2A^*B^*-A^{-1}B^{-1}|$.
+        \begin{answer}
+            $A^* = \lvert A \rvert A^{-1} = 2A^{-1}, B^* = \lvert B \rvert B^{-1} = B^{-1}$，故 \[\lvert 2A^*B^*-A^{-1}B^{-1} \rvert = \lvert 4A^{-1}B^{-1}-A^{-1}B^{-1} \rvert = \lvert 3A^{-1}B^{-1} \rvert = \dfrac{3^n}{\lvert A \rvert \lvert B \rvert} = \dfrac{3^n}{2}.\]
+        \end{answer}
 
         \item 若$n$阶非零矩阵$A$满足$A^\mathrm{T}=A^*$，证明：
         \begin{enumerate}
@@ -2063,8 +2822,26 @@
 
             \item $n>2$且为奇数时，$|E-A|=0$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 设 $A = (a_{ij})$，则 $A^* = (A_{ji})$（$A^*$ 的表达式）. 而 $A^T = A^*$，有 $a_{ij} = A_{ij}, \forall i, j = 1, 2, \ldots, n$. 而 $A$ 非零，故 $\exists a_{kl} \neq 0$，从而有 \[ \lvert A \rvert = a_{k1}A_{k1}+\cdots+a_{kn}A_{kn} = a_{k1}^2+\cdots+a_{kn}^2 > 0.\]
+
+                \item $\lvert A \rvert > 0$ 有 $A$ 是可逆的，故 $A^* = \lvert A \rvert A^{-1} = A^{\mathrm{T}}$，从而 $A^{\mathrm{T}}A = \lvert A \rvert E$. 两侧取行列式有 $\lvert A \rvert^2 = \lvert A \rvert^n $，结合 $\lvert A \rvert > 0$ 有 $\lvert A \rvert = 1$.
+
+                \item $\lvert A \rvert = 1$，故 $A^{-1} = A^{\mathrm{T}}$，$A$ 是正交矩阵.
+
+                \item \begin{align*}
+                          \lvert E-A \rvert & = \lvert AA^{\mathrm{T}}-AE \rvert = \lvert A \rvert \lvert A^{\mathrm{T}}-E\rvert = \lvert A^{\mathrm{T}}-E\rvert = \lvert (A-E)^{\mathrm{T}} \rvert \\
+                                            & = \lvert A-E \rvert = (-1)^n\lvert E-A \rvert.
+                      \end{align*}
+                      $n$ 为奇数，则 $\lvert E-A \rvert = -\lvert E-A \rvert$，即 $\lvert E-A \rvert = 0$.
+            \end{enumerate}
+        \end{answer}
 
         \item 已知$A$是一个秩为$n-1$的$n\enspace(n \geqslant 2)$阶方阵，且已知某个元素$a_{ij}$的代数余子式$A_{ij} \neq 0$，求方程组$AX=0$的基础解系.
+        \begin{answer}
+            $r(A) = n-1$，则 $\lvert A \rvert = 0$ 且 $AX = 0$ 的解空间的维数为 1. 而考虑 $AA^* = \lvert A \rvert E = 0$，且 $\exists A_{ij} \neq 0$，所以 $(A_{i1}, A_{i2}, \ldots , A_{in})^{\mathrm{T}}$ 是所求的基础解系.
+        \end{answer}
 
         \item 设$D=|a_{ij}|_{n \times n}$，$A_{ij}$是$a_{ij}$的代数余子式. 求证：
         \[\begin{vmatrix}
@@ -2073,8 +2850,41 @@
                 \vdots    & \vdots    & \ddots & \vdots      \\
                 A_{n-1,1} & A_{n-1,2} & \cdots & A_{n-1,n-1}
             \end{vmatrix}=a_{nn}D^{n-2}.\]
+        \begin{answer}
+            设 \[A = \begin{pmatrix}
+                a_{11} & a_{12} & \cdots & a_{1n} \\
+                a_{21} & a_{22} & \cdots & a_{2n} \\
+                \vdots & \vdots & \ddots & \vdots \\
+                a_{n1} & a_{n2} & \cdots & a_{nn} \\
+            \end{pmatrix},\]
+            则 \[A^* = \begin{pmatrix}
+                    A_{11}     & A_{21}     & \cdots & A_{n-1, 1}   & A_{n1}     \\
+                    A_{12}     & A_{22}     & \cdots & A_{n-1, 2}   & A_{n2}     \\
+                    \vdots     & \vdots     & \ddots & \vdots       & \vdots     \\
+                    A_{1, n-1} & A_{2, n-1} & \cdots & A_{n-1, n-1} & A_{n, n-1} \\
+                    A_{1n}     & A_{2n}     & \cdots & A_{n-1, n}   & A_{nn}     \\
+                \end{pmatrix}.\]
+            注意到目标行列式是 $A^*$ 中元素 $A_{nn}$ 的代数余子式，也就是 $(A^*)^*$ 中 $(n, n)$ 位置的元素. 由 {例13.9(4)} $(A^*)^* = \lvert A \rvert^{n-2}A$ 可知结论成立. % FIXME: xref
+        \end{answer}
 
         \item 设$a_1,a_2,\ldots,a_n$为互不相等的实数，$b_1,b_2,\ldots,b_n$为任意给定的实数. 证明：存在唯一的$n-1$次多项式，满足$f(a_i)=b_i,\enspace i=1,2,\ldots,n$.
+        \begin{answer}
+            设 $f(x) = c_0+c_1x+c_2x^2+\cdots+c_{n-1}x^{n-1}$，则有
+            \[\begin{cases} \begin{aligned}
+                        c_0+c_1a_1+c_2a_1^2+\cdots+c_{n-1}a_1^{n-1} & = b_1,            \\
+                        c_0+c_1a_2+c_2a_2^2+\cdots+c_{n-1}a_2^{n-1} & = b_2,            \\
+                                                                    & \vdotswithin{ = } \\
+                        c_0+c_1a_n+c_2a_n^2+\cdots+c_{n-1}a_n^{n-1} & = b_n.            \\
+                    \end{aligned} \end{cases}\]
+            注意此处我们研究的对象是 $(c_0, c_1, \ldots, c_{n-1})^{\mathrm{T}}$. 因为系数行列式
+            \[D = \begin{vmatrix}
+                    1      & a_1    & \cdots & a_1^{n-1} \\
+                    1      & a_2    & \cdots & a_2^{n-1} \\
+                    \vdots & \vdots & \ddots & \vdots    \\
+                    1      & a_n    & \cdots & a_n^{n-1} \\
+                \end{vmatrix} = \prod_{1 \leqslant j < i \leqslant n} (a_i-a_j) \neq 0.\]
+            所以由 Cramer 法则，上述关于 $(c_0, c_1, \ldots, c_{n-1})^{\mathrm{T}}$ 的方程组有唯一解，所以满足条件的多项式函数 $f$ 是唯一存在的.
+        \end{answer}
 
         \item 设 $a_1,a_2,\ldots,a_n$ 是 $n$ 个两两互异的实数，$f_1(x),f_2(x),\ldots,f_n(x)$ 是 $n$ 个次数不大于 $n-2$ 的实系数多项式，证明：
 
@@ -2084,6 +2894,13 @@
                 \vdots   & \vdots   & \ddots & \vdots   \\
                 f_n(a_1) & f_n(a_2) & \cdots & f_n(a_n)
             \end{vmatrix}=0.\]
+        \begin{answer}
+            设 $f_i(x) = c_0 + c_1 x + c_2 x^2 + \cdots + c_{n-2} x^{n-2} \in R[x]_{n-1}$，由于 $n-1$ 维线性空间中的 $n$ 个向量必线性相关，我们可以得到 $\left\{ f_1(x), f_2(x), \ldots, f_n(x) \right\}$ 线性相关. 即存在不全为零的 $k_1, k_2, \ldots, k_n$，使得 $\forall x \in \mathbb{R}, k_1 f_1(x) + k_2 f_2(x) + \cdots + k_n f_n(x) = 0$. 设原行列式的行向量分别为 $\alpha_1, \alpha_2, \ldots, \alpha_n$，则有
+            \[
+                k_1 \alpha_1 + k_2 \alpha_2 + \cdots + k_n \alpha_n = \mathbf{0}.
+            \]
+            原行列式的行向量组线性相关，因此其值为 $0$.
+        \end{answer}
 
         \item 证明：$n$维向量组$\alpha_1,\alpha_2,\ldots,\alpha_n$线性无关的充要条件是
         \[\begin{vmatrix}
@@ -2092,8 +2909,33 @@
                 \vdots                      & \vdots                      & \ddots & \vdots                      \\
                 \alpha_n^\mathrm{T}\alpha_1 & \alpha_n^\mathrm{T}\alpha_2 & \cdots & \alpha_n^\mathrm{T}\alpha_n
             \end{vmatrix}\neq 0.\]
+        \begin{answer}
+            令 $A = (\alpha_1, \alpha_2, \ldots, \alpha_n), B = \begin{pmatrix}
+                \alpha_1^{\mathrm{T}}\alpha_1 & \alpha_1^{\mathrm{T}}\alpha_2 & \cdots & \alpha_1^{\mathrm{T}}\alpha_n \\
+                \alpha_2^{\mathrm{T}}\alpha_1 & \alpha_2^{\mathrm{T}}\alpha_2 & \cdots & \alpha_2^{\mathrm{T}}\alpha_n \\
+                \vdots                        & \vdots                        & \ddots & \vdots                        \\
+                \alpha_n^{\mathrm{T}}\alpha_1 & \alpha_n^{\mathrm{T}}\alpha_2 & \cdots & \alpha_n^{\mathrm{T}}\alpha_n \\
+            \end{pmatrix}$，显然 $B = A^{\mathrm{T}}A$，由 {11.4 秩不等式第 4 个} 有 $r(B) = r(A)$. 进而 $n$ 维向量组 $(\alpha_1, \alpha_2, \ldots, \alpha_n)$ 线性无关等价于 $r(A) = n$，也就等价于 $r(B) = n$，进而等价于 $\lvert B \rvert \neq 0$，命题得证. % FIXME: xref
+        \end{answer}
 
         \item 设$a_1,\ldots,a_n$为$n$个$n$维向量，证明：向量组$a_1,\ldots,a_n$线性无关的充要条件是任一个$n$维向量都可以由其线性表示（不使用线性空间维数的方式完成）.
+        \begin{answer}
+            $(\implies)$ 记 $A = (\alpha_1, \alpha_2, \ldots, \alpha_n), \varepsilon_i = (0, \ldots, 1, 0, \ldots, 0)^{\mathrm{T}}$(第 $i$ 个为 1)，$E = (\varepsilon_1, \varepsilon_2, \ldots, \varepsilon_n)$. 因为 $\alpha_1, \alpha_2, \ldots, \alpha_n$ 是 $n$ 维线性无关的向量组，故 $\lvert A \rvert \neq 0$，即 $A$ 可逆，$A = EA, AA^{-1} = E$,\[(\alpha_1, \alpha_2, \ldots, \alpha_n) = (\varepsilon_1, \varepsilon_2, \ldots, \varepsilon_n)A, (\varepsilon_1, \varepsilon_2, \ldots, \varepsilon_n) = (\alpha_1, \alpha_2, \ldots, \alpha_n)A^{-1}.\] 即 $\alpha_1, \alpha_2, \ldots, \alpha_n$ 与 $\varepsilon_1, \varepsilon_2, \ldots, \varepsilon_n$ 等价. $\varepsilon_1, \varepsilon_2, \ldots, \varepsilon_n$ 为 $\mathbf{R}^n$ 的一个基，能表出任一 $n$ 维向量，故 $\alpha_1, \alpha_2, \ldots, \alpha_n$ 能表出 $\mathbf{R}^n$ 中任一 $n$ 维向量.
+
+            $(\impliedby)$ 若 $\alpha_1, \alpha_2, \ldots, \alpha_n$ 能表出任一 $n$ 维向量，则 $\varepsilon_i = \lambda_{i1}\alpha_1+\cdots+\lambda_{in}\alpha_n, i = 1, 2, \ldots, n$. 即
+            \[E = (\varepsilon_1, \varepsilon_2, \ldots, \varepsilon_n) = (\alpha_1, \alpha_2, \ldots, \alpha_n)\begin{pmatrix}
+                    \lambda_{11} & \lambda_{21} & \cdots & \lambda_{n1} \\
+                    \lambda_{11} & \lambda_{21} & \cdots & \lambda_{n1} \\
+                    \vdots       & \vdots       & \ddots & \vdots       \\
+                    \lambda_{11} & \lambda_{21} & \cdots & \lambda_{n1} \\
+                \end{pmatrix}.\]
+            进而 $\lvert \alpha_1, \alpha_2, \ldots, \alpha_n \rvert \begin{vmatrix}
+                    \lambda_{11} & \lambda_{21} & \cdots & \lambda_{n1} \\
+                    \lambda_{11} & \lambda_{21} & \cdots & \lambda_{n1} \\
+                    \vdots       & \vdots       & \ddots & \vdots       \\
+                    \lambda_{11} & \lambda_{21} & \cdots & \lambda_{n1} \\
+                \end{vmatrix} = 1$，所以 $\lvert \alpha_1, \alpha_2, \ldots, \alpha_n \rvert \neq 0$，$\alpha_1, \alpha_2, \ldots, \alpha_n$ 线性无关.
+        \end{answer}
 
         \item 设$s \times n\enspace(s\leqslant n)$矩阵为
         \[\begin{pmatrix}
@@ -2103,6 +2945,18 @@
                 1      & a^s    & a^{2s} & \cdots & a^{s(n-1)}
             \end{pmatrix}\]
         且$a^r\neq 1\enspace(0<r<n)$，求$A$的秩和它的列向量组的一个极大线性无关组.
+        \begin{answer}
+            $A$ 的前 $s$ 列组成的 $s$ 阶子式为Vandermonde行列式
+            \[D = \begin{vmatrix}
+                    1      & a      & a^2    & \cdots & a^{s-1}    \\
+                    1      & a^2    & a^4    & \cdots & a^{2(s-1)} \\
+                    \vdots & \vdots & \vdots & \ddots & \vdots     \\
+                    1      & a^s    & a^{2s} & \cdots & a^{s(s-1)} \\
+                \end{vmatrix}.\]
+            由于当 $0 < r < n$ 时，$a^r \neq 1$，因此 $a, a^2, \ldots, a^s$ 两两不同，进而 $D \neq 0$，于是 $r(A) \geqslant s$. 又因为 $A$ 的行数是 $s$，所以 $r(A) \leqslant s$. 从而 $r(A) = s$.
+
+            由于 $D \neq 0$，故 $D$ 的列向量线性无关，因此 $A$ 的前 $s$ 个列向量即为其列向量组的一个极大线性无关组.
+        \end{answer}
 
         \item 设$A,B,C,D \in \mathbf{F}^{n \times n}$，定义变换 $ T : \mathbf{F}^{n \times n} \to \mathbf{F}^{n \times n}$ 为
         \[ T(X) = AXB+CX+XD \]
@@ -2112,12 +2966,64 @@
 
             \item 当$C=D=0$时，$T$可逆的充要条件是$|AB| \neq 0$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 线性变换的验证省略.
+
+                \item $(\implies)$ 若 $\lvert AB \rvert = 0$，则 $\lvert A \rvert = 0$ 或 $\lvert B \rvert = 0$，故 $A$ 或 $B$ 不可逆. 不妨假设 $A$ 不可逆，则存在 $X_0 \neq 0$ 使得 $AX_0 = 0$，$T(X_0) = AX_0B = 0$. 但 $T$ 是可逆的，所以 $T$ 是单射，$T(X) = 0 \Leftrightarrow X = 0$，矛盾.
+
+                      $(\impliedby)$ $\lvert AB \rvert \neq 0$ 则 $A, B$ 可逆，故 $T(X) = AXB$ 的逆映射为 $T^{-1}(X) = A^{-1}XB^{-1}$.
+            \end{enumerate}
+        \end{answer}
 
         \item 设$A$为$n$阶矩阵，且$r(A) < n$，又$A_{11} \neq 0$，证明：存在常数$k$，使得$(A^*)^2=kA^*$.
+        \begin{answer}
+            因为 $r(A) < n, A_{11} \neq 0$，所以 $r(A) = n-1$，进而由 {例13.9 (6)} 可知 $r(A^*) = 1$，所以有 % FIXME: xref
+            \[A^* = \begin{pmatrix} a_1 \\ a_2 \\ \vdots \\ a_n \end{pmatrix} (\lambda_1, \lambda_2, \ldots, \lambda_n).\]
+            设 $(\lambda_1, \lambda_2, \ldots, \lambda_n) \begin{pmatrix} a_1 \\ a_2 \\ \vdots \\ a_n \end{pmatrix} = k$，则
+            \begin{align*}
+                (A^*)^2 & = \begin{pmatrix}a_1 \\ a_2 \\ \vdots \\ a_n \end{pmatrix}
+                (\lambda_1, \lambda_2, \ldots, \lambda_n)
+                \begin{pmatrix} a_1 \\ a_2 \\ \vdots \\ a_n \end{pmatrix}
+                (\lambda_1, \lambda_2, \ldots, \lambda_n)                                     \\
+                        & = \begin{pmatrix} a_1 \\ a_2 \\ \vdots \\ a_n \end{pmatrix} \cdot k
+                \cdot (\lambda_1, \lambda_2, \ldots, \lambda_n) = k
+                \begin{pmatrix} a_1 \\ a_2 \\ \vdots \\ a_n \end{pmatrix}
+                (\lambda_1, \lambda_2, \ldots, \lambda_n) = kA^*.
+            \end{align*}
+        \end{answer}
 
         \item 设$V$是一个$n$维实线性空间，证明：存在$V$中的一个由可列无穷多个向量组成的向量组$\{\alpha_i \mid i\in\mathbf{Z}_+\}$，使得其中任意$n$个向量组成的向量组都是$V$的一组基.
+        \begin{answer}
+            $\forall a_i \in \mathbf{R}, i \in \mathbf{Z}_{+}$ 满足：若 $i \neq j$，则 $a_i \neq a_j$，考虑以Vandermonde行列式的形式进行排布. 设
+            \[ A = \begin{pmatrix}
+                    1         & 1         & \cdots & 1         & \cdots \\
+                    a_1       & a_2       & \cdots & a_k       & \cdots \\
+                    a_1^2     & a_2^2     & \cdots & a_k^2     & \cdots \\
+                    \vdots    & \vdots    & \ddots & \vdots    &        \\
+                    a_1^{n-1} & a_2^{n-1} & \cdots & a_k^{n-1} & \cdots
+                \end{pmatrix}.\]
+            考虑 $A$ 的任意 $n$ 阶主子式 $D_n$，其均构成 Vandermonde 行列式，又 $i \neq j$ 有 $a_i \neq a_j$，所以值均不为 0，也就是说任意 $n$ 个向量都线性无关，其个数也恰好为 $n$，构成 $V$ 的一组基，命题得证.
+        \end{answer}
 
         \item 回顾\autoref{ex:函数和数列线性空间} 中数列极限的例子，证明：以$0$为极限的实数数列全体构成的线性空间是无限维线性空间.
+        \begin{answer}
+            易证以 $0$ 为极限的实数数列全体可以构成一个线性空间 $W$，下使用反证法证明 $W$ 为无限维线性空间：
+
+            假设 $W$ 为有限维线性空间，不妨设 $\dim W = k$.
+
+            取 $W$ 中的 $k+1$ 个数列 $\{a_n^{(1)}, a_n^{(2)}, \ldots, a_n^{(k)}, a_n^{(k+1)}\}$，满足 $a_n^{(i)} = (i+1)^{-n} \to 0^+ \enspace (n \to +\infty)$. 分别取这 $k+1$ 个数列的前 $k+1$ 项，构造 Vandermonde 行列式：
+            \[
+                D = \begin{vmatrix}
+                    1          & 1          & \cdots & 1              \\
+                    2^{-1}     & 3^{-1}     & \cdots & (k+2)^{-1}     \\
+                    2^{-2}     & 3^{-2}     & \cdots & (k+2)^{-2}     \\
+                    \vdots     & \vdots     & \ddots & \vdots         \\
+                    2^{-(k-1)} & 3^{-(k-1)} & \cdots & (k+2)^{-(k-1)}
+                \end{vmatrix} \neq 0,
+            \]
+            故行列式的列向量线性无关. 由于线性无关的向量组在补充分量后仍然线性无关，我们可以得到 $k+1$ 个数列 $\{a_n^{(1)}, a_n^{(2)}, \cdots, a_n^{(k)}, a_n^{(k+1)}\}$ 线性无关，这与 $\dim W = k$ 矛盾，因此 $W$ 为无限维线性空间.
+        \end{answer}
 
         \item 解行列式
         \begin{enumerate} \begin{multicols}{2}
@@ -2148,6 +3054,34 @@
                         0 & 0 & 1 & 3
                     \end{vmatrix} $
             \end{multicols} \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 连加法得结果为160；
+
+                \item 连加法得结果为$(\lambda-1)(\lambda+3)^3$；
+
+                \item 如果对数据敏感能看出线性相关，可以直接由$\alpha_4-\alpha_1=3(\alpha_3-\alpha_2)$证得其线性相关，则为0. 也可以使用滚动消去法，如\[
+                          \begin{vmatrix}
+                              1 & 4 & 9  & 16 \\
+                              3 & 5 & 7  & 9  \\
+                              5 & 7 & 9  & 11 \\
+                              7 & 9 & 11 & 13
+                          \end{vmatrix}=\begin{vmatrix}
+                              1 & 4 & 9 & 16 \\
+                              3 & 5 & 7 & 9  \\
+                              2 & 2 & 2 & 2  \\
+                              2 & 2 & 2 & 2
+                          \end{vmatrix}=0.\]
+
+                \item 当然是递推法的常见形式，但是只有4阶，所以可以暴算，转化为上三角行列式，如\[
+                          \begin{vmatrix}
+                              3 & 2           & 0            & 0             \\
+                              0 & \frac{7}{3} & 2            & 0             \\
+                              0 & 0           & \frac{15}{7} & 2             \\
+                              0 & 0           & 0            & \frac{31}{15}
+                          \end{vmatrix}=31.\]
+            \end{enumerate}
+        \end{answer}
 
         \item 解行列式 $\begin{vmatrix}
                 a_{1}+a_{2}         & a_{2}+a_{3}         & \cdots & a_{n-1}+a_n         & a_n+a_{1}         \\
@@ -2155,6 +3089,37 @@
                 \vdots              & \vdots              & \ddots & \vdots              & \vdots            \\
                 a_{1}^{n}+a_{2}^{n} & a_{2}^{n}+a_{3}^{n} & \cdots & a_{n-1}^{n}+a_n^{n} & a_n^{n}+a_{1}^{n}
             \end{vmatrix}$.
+        \begin{answer}
+            暴力拆成$2^n$个行列式，其中只有2个每列各不相同，其他都因为有相同列而为0. 因此有
+            \begin{align*}
+                \text{原式} & =\begin{vmatrix}
+                                    a_{1}     & a_{2}     & \cdots & a_{n-1}     & a_{n}     \\
+                                    a_{1}^{2} & a_{2}^{2} & \cdots & a_{n-1}^{2} & a_{n}^{2} \\
+                                    \vdots    & \vdots    & \ddots & \vdots      & \vdots    \\
+                                    a_{1}^{n} & a_{2}^{n} & \cdots & a_{n-1}^{n} & a_{n}^{n}
+                                \end{vmatrix}+
+                \begin{vmatrix}
+                    a_{2}     & a_{3}     & \cdots & a_{n}     & a_{1}     \\
+                    a_{2}^{2} & a_{3}^{2} & \cdots & a_{n}^{2} & a_{1}^{2} \\
+                    \vdots    & \vdots    & \ddots & \vdots    & \vdots    \\
+                    a_{2}^{n} & a_{3}^{n} & \cdots & a_{n}^{n} & a_{1}^{n}
+                \end{vmatrix}                                               \\
+                            & =(1+(-1)^{n-1})\begin{vmatrix}
+                                                a_{1}     & a_{2}     & \cdots & a_{n-1}     & a_{n}     \\
+                                                a_{1}^{2} & a_{2}^{2} & \cdots & a_{n-1}^{2} & a_{n}^{2} \\
+                                                \vdots    & \vdots    & \ddots & \vdots      & \vdots    \\
+                                                a_{1}^{n} & a_{2}^{n} & \cdots & a_{n-1}^{n} & a_{n}^{n}
+                                            \end{vmatrix}                \\
+                            & =(1+(-1)^{n-1})\prod_{i=1}^na_i
+                \begin{vmatrix}
+                    1           & 1           & \cdots & 1             & 1           \\
+                    a_{1}       & a_{2}       & \cdots & a_{n-1}       & a_{n}       \\
+                    \vdots      & \vdots      & \ddots & \vdots        & \vdots      \\
+                    a_{1}^{n-1} & a_{2}^{n-1} & \cdots & a_{n-1}^{n-1} & a_{n}^{n-1}
+                \end{vmatrix}                                     \\
+                            & =(1+(-1)^{n-1})\left(\prod_{i=1}^na_i\right)\prod_{1\leqslant i<j\leqslant n}(a_j-a_i). \\
+            \end{align*}
+        \end{answer}
 
         \item 解行列式
         \begin{multicols}{2} \begin{enumerate}
@@ -2170,8 +3135,90 @@
                               xz    & yz    & z^2+1
                           \end{vmatrix}$
             \end{enumerate} \end{multicols}
+        \begin{answer}
+            \begin{enumerate}
+                \item 可以硬拆成8个行列式，其中只有2个非零，则得到
+                      \[D=\begin{vmatrix}
+                              ax & ay & az \\
+                              ay & az & ax \\
+                              az & ax & ay
+                          \end{vmatrix}+\begin{vmatrix}
+                              by & bz & bx \\
+                              bz & bx & by \\
+                              bx & by & bz \\
+                          \end{vmatrix}=(a+b)\begin{vmatrix}
+                              x & y & z \\
+                              y & z & x \\
+                              z & x & y \\
+                          \end{vmatrix}=(a^3+b^3)(3xyz-\sum x^2),\]
+                      另解：分解成两个矩阵相乘再各自求行列式. 这其实是看出这是一种线性变换的本质之后的做法：
+                      \[D=\begin{vmatrix}
+                              \begin{pmatrix}
+                                  a & b & 0 \\
+                                  0 & a & b \\
+                                  b & 0 & a \\
+                              \end{pmatrix}
+                              \begin{pmatrix}
+                                  x & y & z \\
+                                  y & z & x \\
+                                  z & x & y \\
+                              \end{pmatrix}
+                          \end{vmatrix}.\]
+
+                \item 其实直接用三阶行列式的公式也不错，这里介绍基于硬拆的方法
+                      \begin{align*}
+                          D & =x\begin{vmatrix}
+                                    x & xy    & xz    \\
+                                    y & y^2+1 & yz    \\
+                                    z & yz    & z^2+1
+                                \end{vmatrix}+\begin{vmatrix}
+                                                  1 & xy    & xz    \\
+                                                  0 & y^2+1 & yz    \\
+                                                  0 & yz    & z^2+1
+                                              \end{vmatrix} \\
+                            & =x\begin{vmatrix}
+                                    x & 0 & 0 \\
+                                    y & 1 & 0 \\
+                                    z & 0 & 1
+                                \end{vmatrix}+\begin{vmatrix}
+                                                  y^2+1 & yz    \\
+                                                  yz    & z^2+1
+                                              \end{vmatrix}
+                          =\sum x^2+1.
+                      \end{align*}
+            \end{enumerate}
+        \end{answer}
 
         \item 计算行列式$|2E-\alpha_1^\mathrm{T}\beta_1-\alpha_2^\mathrm{T}\beta_2|$，其中$\alpha_1=(a_1,a_2,\ldots,a_n),\enspace \beta_1=(b_1,b_2,\ldots,b_n),\enspace \alpha_2=(c_1,c_2,\ldots,c_n),\enspace \beta_2 = (d_1,d_2,\ldots,d_n)$.（提示：利用$|\lambda E_m-AB|=\lambda^{m-n}|\lambda E_n-BA|$）
+        \begin{answer}
+            利用$|\lambda E_m-AB|=\lambda^{m-n}|\lambda E_n-BA|$
+            \begin{align*}
+                |2E-\alpha_1^\mathrm{T}\beta_1-\alpha_2^\mathrm{T}\beta_2|
+                & =\begin{vmatrix}
+                        2E-\begin{pmatrix}
+                        \alpha_1^\mathrm{T} & \alpha_2^\mathrm{T}
+                    \end{pmatrix}\begin{pmatrix}
+                                        \beta_1 \\\beta_2
+                                    \end{pmatrix}
+                    \end{vmatrix}
+                =2^{n-2}\begin{vmatrix}
+                            2E-\begin{pmatrix}
+                        \beta_1 \\\beta_2
+                    \end{pmatrix}\begin{pmatrix}
+                                        \alpha_1^\mathrm{T} & \alpha_2^\mathrm{T}
+                                    \end{pmatrix}
+                        \end{vmatrix}         \\
+                & =2^{n-2}\begin{vmatrix}
+                            2-\beta_1\alpha_1^\mathrm{T} & -\beta_1\alpha_2^\mathrm{T}  \\
+                            -\beta_2\alpha_1^\mathrm{T}  & 2-\beta_2\alpha_2^\mathrm{T}
+                        \end{vmatrix} \\
+                & =2^{n-2}
+                \left(\left(2-\sum_{i=1}^na_ib_i\right)
+                \left(2-\sum_{i=1}^nc_id_i\right)
+                -\left(\sum_{i=1}^na_id_i\right)
+                \left(\sum_{i=1}^nb_ic_i\right)\right)
+            \end{align*}
+        \end{answer}
 
         \item 求$2n$阶行列式的值（空缺处都是0）：
         \[\begin{vmatrix}
@@ -2182,10 +3229,77 @@
                   & \iddots &   &   & \ddots  &   \\
                 b &         &   &   &         & a
             \end{vmatrix}.\]
+        \begin{answer}
+            设所求 $2n$ 阶行列式为 $D$.
+            \begin{enumerate}
+                \item 若 $a=0$，则
+                    \[
+                        D = \begin{vmatrix}
+                            0 &         &   &   &         & b \\
+                              & \ddots  &   &   &         &   \\
+                              &         & 0 & b &         &   \\
+                              &         & b & 0 &         &   \\
+                              &         &   &   & \ddots  &   \\
+                            b &         &   &   &         & 0
+                        \end{vmatrix}
+                        = (-1)^{\frac{2n(2n-1)}{2}} \begin{vmatrix}
+                            b &         &   &   &         & 0 \\
+                              & \ddots  &   &   &         &   \\
+                              &         & b & 0 &         &   \\
+                              &         & 0 & b &         &   \\
+                              &         &   &   & \ddots  &   \\
+                            0 &         &   &   &         & b
+                        \end{vmatrix}
+                        = b^{2n}.
+                    \]
+                \item 若 $b \neq 0$，我们将第 $i$ 列乘以 $-\dfrac{b}{a}$ 后加到第 $2n-i+1$ 列，化为下三角矩阵：
+                    \[
+                        D = \begin{vmatrix}
+                            a &         &   &                   &         & 0                 \\
+                              & \ddots  &   &                   &         &                   \\
+                              &         & a & 0                 &         &                   \\
+                              &         & b & a - \frac{b^2}{a} &         &                   \\
+                              &         &   &                   & \ddots  &                   \\
+                            b &         &   &                   &         & a - \frac{b^2}{a}
+                        \end{vmatrix}
+                        = a^n (a - \frac{b^2}{a})^n
+                        = (a^2 - b^2)^n.
+                    \]
+            \end{enumerate}
+        \end{answer}
     \end{exgroup}
 
     \begin{exgroup}
         \item 设$A=(a_{ij})$是$n\enspace(n\geqslant 2)$阶整数方阵，满足对任意的$i,j$，$|A|$均可整除$a_{ij}$，证明：$|A|=\pm 1$.
+        \begin{answer}
+            设 $a_{ij} = |A| b_{ij}$，其中 $b_{ij}$ 为整数，则
+            \[
+                |A| = \begin{vmatrix}
+                    |A| b_{11} & |A| b_{12} & \cdots & |A| b_{1n} \\
+                    |A| b_{21} & |A| b_{22} & \cdots & |A| b_{2n} \\
+                    \vdots     & \vdots     & \ddots & \vdots     \\
+                    |A| b_{n1} & |A| b_{n2} & \cdots & |A| b_{nn}
+                \end{vmatrix}
+                = |A|^n \begin{vmatrix}
+                    b_{11} & b_{12} & \cdots & b_{1n} \\
+                    b_{21} & b_{22} & \cdots & b_{2n} \\
+                    \vdots & \vdots & \ddots & \vdots \\
+                    b_{n1} & b_{n2} & \cdots & b_{nn}
+                \end{vmatrix}.
+            \]
+
+            由此可得
+            \[
+                |A|^{n-1} \begin{vmatrix}
+                    b_{11} & b_{12} & \cdots & b_{1n} \\
+                    b_{21} & b_{22} & \cdots & b_{2n} \\
+                    \vdots & \vdots & \ddots & \vdots \\
+                    b_{n1} & b_{n2} & \cdots & b_{nn}
+                \end{vmatrix} = 1.
+            \]
+
+            由于 $a_{ij}$ 与 $b_{ij}$ 均为整数，所以 $|A|$ 与 $|b_{ij}|_{n \times n}$ 也为整数，且 $|A| \neq 0$，所以 $|A| = \pm 1$.
+        \end{answer}
 
         \item 设$f_{ij}(t)$是可微函数，
         \[F(t)=\begin{vmatrix}
@@ -2201,19 +3315,208 @@
                 \vdots    & \vdots    & \ddots & \vdots                                   & \vdots & \vdots    \\[2ex]
                 f_{n1}(t) & f_{n2}(t) & \cdots & \dfrac{\mathrm{d}}{\mathrm{d}t}f_{nj}(t) & \cdots & f_{nn}(t)
             \end{vmatrix}.\]
+        \begin{answer}
+            使用数学归纳法证明. 当 $n=1$ 时，$\dfrac{\mathrm{d}}{\mathrm{d}t}F(t) = \left\lvert \dfrac{\mathrm{d}}{\mathrm{d}t}f_{11}(t) \right\rvert$，结论成立.
+
+            假设 $n=k-1$ 时结论成立，下证 $n=k$ 时结论也成立. 设 $G_{ij}(t)$ 为 $F(t)$ 对 $f_{ij}(t)$ 的代数余子式，将 $F(t)$ 按第一列展开：
+            \[
+                F(t) = \sum_{i=1}^k f_{i1}(t) G_{i1}(t),
+            \]
+
+            对 $t$ 求导，有
+            \[
+                \dfrac{\mathrm{d}}{\mathrm{d}t}F(t) = \sum_{i=1}^k \dfrac{\mathrm{d}f_{i1}(t)}{\mathrm{d}t} G_{i1}(t) + \sum_{i=1}^k f_{i1}(t) \dfrac{\mathrm{d}G_{i1}(t)}{\mathrm{d}t}.
+            \]
+
+            上式第一部分和即为 $F_1(t)$. 下求第二部分的和：
+
+            设 $F_{ij}(t)$ 为 $F_j(t)$ 对 $f_{i1}$ 的代数余子式，即
+            \[
+                F_{ij}(t) = \begin{vmatrix}
+                    f_{12}(t) & f_{13}(t) & \cdots & \dfrac{\mathrm{d}}{\mathrm{d}t}f_{1j}(t) & \cdots & f_{1k}(t) \\[2ex]
+                    f_{22}(t) & f_{23}(t) & \cdots & \dfrac{\mathrm{d}}{\mathrm{d}t}f_{2j}(t) & \cdots & f_{2k}(t) \\[2ex]
+                    \vdots    & \vdots    &        & \vdots                                   & \vdots & \vdots    \\[2ex]
+                    f_{i-1,2}(t) & f_{i-1,3}(t) & \cdots & \dfrac{\mathrm{d}}{\mathrm{d}t}f_{i-1,j}(t) & \cdots & f_{i-1,k}(t) \\[2ex]
+                    f_{i+1,2}(t) & f_{i+1,3}(t) & \cdots & \dfrac{\mathrm{d}}{\mathrm{d}t}f_{i+1,j}(t) & \cdots & f_{i+1,k}(t) \\[2ex]
+                    \vdots    & \vdots    &        & \vdots                                   & \vdots & \vdots    \\[2ex]
+                    f_{k2}(t) & f_{k3}(t) & \cdots & \dfrac{\mathrm{d}}{\mathrm{d}t}f_{kj}(t) & \cdots & f_{kk}(t)
+                \end{vmatrix}.
+            \]
+
+            将第二部分中的 $\dfrac{\mathrm{d}G_{i1}(t)}{\mathrm{d}t}$ 按归纳假设展开，可得
+            \begin{align*}
+                \sum_{i=1}^k f_{i1}(t) \dfrac{\mathrm{d}G_{i1}(t)}{\mathrm{d}t}
+                &= \sum_{i=1}^k \sum_{j=2}^k F_{ij}(t) f_{i1}(t) \\
+                &= \sum_{j=2}^k \sum_{i=1}^k F_{ij}(t) f_{i1}(t) \\
+                &= \sum_{j=2}^k F_j(t).
+            \end{align*}
+
+            与第一部分合并可得
+            \[
+                \dfrac{\mathrm{d}}{\mathrm{d}t}F(t)=\sum\limits_{j=1}^nF_j(t).
+            \]
+
+        \end{answer}
 
         \item 设$A,B,C,D$均为$n$阶方阵，$\lvert A \rvert \neq 0$且$AC=CA$. 证明：
         \[\begin{vmatrix}
                 A & B \\ C & D
             \end{vmatrix} = |AD-CB|.\]
+        \begin{answer}
+            对原矩阵进行分块初等变换化为上三角块矩阵后进行计算. 因为 $\lvert A \rvert \neq 0$，所以 $A$ 可逆，进而有如下变换：
+            \[\begin{pmatrix}
+                    E        & O \\
+                    -CA^{-1} & E
+                \end{pmatrix} \begin{pmatrix}
+                    A & B \\
+                    C & D \\
+                \end{pmatrix} = \begin{pmatrix}
+                    A & B          \\
+                    O & D-CA^{-1}B
+                \end{pmatrix},\]
+            所以
+            \begin{align*}
+                    & \begin{vmatrix}
+                            A & B \\
+                            C & D \\
+                        \end{vmatrix}
+                = \begin{vmatrix}
+                        E        & O \\
+                        -CA^{-1} & E \\
+                    \end{vmatrix}
+                \begin{vmatrix}
+                    A & B \\
+                    C & D \\
+                \end{vmatrix}       \\
+                ={} & \begin{vmatrix}
+                            A & B          \\
+                            O & D-CA^{-1}B
+                        \end{vmatrix}
+                = \lvert A \rvert \lvert D-CA^{-1}B \rvert = \lvert AD-ACA^{-1}B \rvert.
+            \end{align*} 由于 $AC = CA$，所以有 $ACA^{-1} = CAA^{-1} = C$，所以
+            \[\begin{vmatrix}
+                    A & B \\
+                    C & D \\
+                \end{vmatrix} = \lvert AD-CB \rvert.\]
+        \end{answer}
 
         \item 设$A$为$n$阶可逆矩阵，$\alpha,\beta$为$n$维列向量，证明：
         \[|A+\alpha\beta^{\mathrm{T}}|=|A|(1+\beta^\mathrm{T}A^{-1}\alpha).\]
+        \begin{answer}
+            这道题目我们利用了一个分块矩阵作为中间``桥梁''使得其通过分块初等变换之后能分别得到两个方向上的结果. 考虑矩阵 $\begin{pmatrix}
+                A                   & \alpha \\
+                -\beta^{\mathrm{T}} & 1
+            \end{pmatrix}$，有
+            \[\begin{pmatrix}
+                    A                   & \alpha \\
+                    -\beta^{\mathrm{T}} & 1
+                \end{pmatrix} \begin{pmatrix}
+                    E                  & O \\
+                    \beta^{\mathrm{T}} & E
+                \end{pmatrix} = \begin{pmatrix}
+                    A+\alpha \beta^{\mathrm{T}} & \alpha \\
+                    O                           & 1
+                \end{pmatrix},\]
+            所以
+            \[\begin{vmatrix}
+                    A                   & \alpha \\
+                    -\beta^{\mathrm{T}} & 1
+                \end{vmatrix} = \begin{vmatrix}
+                    A                   & \alpha \\
+                    -\beta^{\mathrm{T}} & 1
+                \end{vmatrix} \begin{vmatrix}
+                    E                  & O \\
+                    \beta^{\mathrm{T}} & E
+                \end{vmatrix} = \begin{vmatrix}
+                    A+\alpha \beta^{\mathrm{T}} & \alpha \\
+                    O                           & 1
+                \end{vmatrix} = \lvert A+\alpha \beta^{\mathrm{T}} \rvert.\]
+            另一方面，
+            \[\begin{pmatrix}
+                    E                        & O \\
+                    \beta^{\mathrm{T}}A^{-1} & 1
+                \end{pmatrix} \begin{pmatrix}
+                    A                   & \alpha \\
+                    -\beta^{\mathrm{T}} & 1
+                \end{pmatrix} = \begin{pmatrix}
+                    A & \alpha                           \\
+                    O & 1+\beta^{\mathrm{T}}A^{-1}\alpha
+                \end{pmatrix}.\]
+            注意 $\beta^{\mathrm{T}}A^{-1}\alpha$ 的最终结果是一个数. 进而
+            \[\begin{vmatrix}
+                    A                   & \alpha \\
+                    -\beta^{\mathrm{T}} & 1
+                \end{vmatrix} = \begin{vmatrix}
+                    E                        & O \\
+                    \beta^{\mathrm{T}}A^{-1} & 1
+                \end{vmatrix} \begin{vmatrix}
+                    A                   & \alpha \\
+                    -\beta^{\mathrm{T}} & 1
+                \end{vmatrix} = \begin{vmatrix}
+                    A & \alpha                           \\
+                    O & 1+\beta^{\mathrm{T}}A^{-1}\alpha
+                \end{vmatrix} = \lvert A \rvert(1+\beta^{\mathrm{T}}A^{-1}\alpha).\]
+            所以有
+            \[\lvert A+\alpha \beta^{\mathrm{T}} \rvert = \lvert A \rvert(1+\beta^{\mathrm{T}}A^{-1}\alpha).\]
+        \end{answer}
 
         \item 设$A,B$均为$n$阶方阵，证明：
         \[\begin{vmatrix}
                 A & B \\ B & A
             \end{vmatrix} = |A+B||A-B|.\]
+        \begin{answer}
+            依旧是对分块矩阵做初等分块变换. 考虑到
+            \begin{align*}
+                \left(\begin{pmatrix}
+                            E & E \\
+                            O & E
+                        \end{pmatrix}
+                \begin{pmatrix}
+                    A & B \\
+                    B & A
+                \end{pmatrix} \right)
+                \begin{pmatrix}
+                    E & -E \\
+                    O & E
+                \end{pmatrix}
+                & = \begin{pmatrix}
+                        A+B & A+B \\
+                        B   & A
+                    \end{pmatrix}
+                \begin{pmatrix}
+                    E & -E \\
+                    O & E
+                \end{pmatrix}      \\
+                & = \begin{pmatrix}
+                        A+B & O   \\
+                        B   & A-B
+                    \end{pmatrix},
+            \end{align*}
+            所以有 \begin{align*}
+                \begin{vmatrix}
+                    A & B \\
+                    B & A
+                \end{vmatrix}
+                & = \begin{vmatrix}
+                        E & E \\
+                        O & E
+                    \end{vmatrix}
+                \begin{vmatrix}
+                    A & B \\
+                    B & A
+                \end{vmatrix}
+                \begin{vmatrix}
+                    E & -E \\
+                    O & E
+                \end{vmatrix}
+                = \begin{vmatrix}
+                        A+B & O   \\
+                        B   & A-B
+                    \end{vmatrix}    \\
+                & =
+                \lvert (A+B)(A-B) \rvert = \lvert A+B \rvert \lvert A-B \rvert
+            \end{align*}
+        \end{answer}
 
         \item 设$A,B,C,D$均为$n$阶方阵，且$r\begin{pmatrix}
                 A & B \\ C & D
@@ -2221,14 +3524,192 @@
         \[\begin{vmatrix}
                 |A| & |B| \\ |C| & |D|
             \end{vmatrix} = 0.\]
+        \begin{answer}
+            首先有 $\begin{vmatrix}
+                \lvert A \rvert & \lvert B \rvert \\
+                \lvert C \rvert & \lvert D \rvert
+            \end{vmatrix} = \lvert A \rvert \lvert D \rvert-\lvert B \rvert \lvert C \rvert$.
+            \begin{enumerate}
+                \item 若 $\lvert A \rvert \neq 0$，即 $A$ 可逆. 因为矩阵的初等变换不改变矩阵的秩，所以由
+                    \[\begin{pmatrix}
+                            E        & O \\
+                            -CA^{-1} & E
+                        \end{pmatrix} \begin{pmatrix}
+                            A & B \\
+                            C & D
+                        \end{pmatrix} \begin{pmatrix}
+                            E & -A^{-1}B \\
+                            O & E        \\
+                        \end{pmatrix} = \begin{pmatrix}
+                            A & O          \\
+                            O & D-CA^{-1}B
+                        \end{pmatrix},\]
+                    条件 $r\left(\begin{pmatrix}
+                                A & B \\
+                                C & D
+                            \end{pmatrix}\right) = n$ 以及 $A$ 可逆，可以得到
+                    \[D-CA^{-1}B = O.\]
+                    即若 $A$ 可逆，则 $D = CA^{-1}B$，并且
+                    \[\begin{vmatrix}
+                            \lvert A \rvert & \lvert B \rvert \\
+                            \lvert C \rvert & \lvert D \rvert
+                        \end{vmatrix} = \lvert A \rvert \lvert CA^{-1}B \rvert-\lvert B \rvert \lvert C \rvert = \lvert A \rvert \lvert C \rvert \lvert A^{-1} \rvert \lvert B \rvert-\lvert B \rvert \lvert C \rvert = 0.\]
+
+                \item 若 $\lvert A \rvert = 0$，只需证 $\lvert B \rvert \lvert C \rvert = 0$. 若 $\lvert B \rvert \neq 0$，则由
+                    \[\begin{pmatrix}
+                            E        & O \\
+                            -DB^{-1} & E
+                        \end{pmatrix} \begin{pmatrix}
+                            A & B \\
+                            C & D
+                        \end{pmatrix} \begin{pmatrix}
+                            E        & O \\
+                            -B^{-1}A & E
+                        \end{pmatrix} = \begin{pmatrix}
+                            O          & B \\
+                            C-DB^{-1}A & O
+                        \end{pmatrix},\]
+                    有 $C-DB^{-1}A = O$. 注意到 $\lvert A \rvert = 0$，故 \[\lvert C \rvert = \lvert DB^{-1}A \rvert = \lvert D \rvert \lvert B^{-1} \rvert \lvert A \rvert = 0.\] 同理可证若 $\lvert C \rvert \neq 0$，则 $\lvert B \rvert = 0$.
+            \end{enumerate}
+            综上，结论成立.
+        \end{answer}
 
         \item 设$A$为$n$阶实对称矩阵（$n>1$），$|A|=0$，证明：$A_{ii}A_{jj}=(A_{ij})^2(i,j=1,\ldots,n)$.
+        \begin{answer}
+            由 $|A| = 0$ 可知 $r(A) < n$. 利用结论
+            \[
+                r(A^*)=\begin{cases}
+                    n & r(A)=n     \\
+                    1 & r(A)=n-1   \\
+                    0 & r(A) < n-1
+                \end{cases}
+            \]
+            可知 $r(A^*) \leqslant 1$.
+
+            若 $r(A^*) = 0$，则 $A^* = O$，故 $A_{ii} = A_{jj} = A_{ij} = 0$，自然有 $A_{ii}A_{jj}=(A_{ij})^2$；
+
+            若 $r(A^*) = 1$，则 $A^*$ 的任意两个列向量线性相关，可得 $A_{ii}A_{jj} = A_{ij}A_{ji}$. 又由 $A$ 是实对称矩阵，有 $A_{ij} = A_{ji}$，因此 $A_{ii}A_{jj} = (A_{ij})^2$.
+
+        \end{answer}
 
         \item 求$\begin{pmatrix}
                 A & C \\ O & B
             \end{pmatrix}^*$，并求当$A$可逆时的$\begin{pmatrix}
                 A & B \\ C & D
             \end{pmatrix}^*$.
+        \begin{answer}
+            \begin{enumerate}
+                \item 设 $\begin{pmatrix}
+                              A & C \\
+                              O & B
+                          \end{pmatrix}$ 的伴随矩阵为 $\begin{pmatrix}
+                              X & Y \\
+                              Z & W
+                          \end{pmatrix}$. 而 $\begin{vmatrix}
+                              A & C \\
+                              O & B
+                          \end{vmatrix} = \lvert A\rvert \lvert B \rvert$，所以有
+                      \[\begin{pmatrix}
+                              A & C \\
+                              O & B
+                          \end{pmatrix} \begin{pmatrix}
+                              X & Y \\
+                              Z & W
+                          \end{pmatrix} = \lvert A\rvert \lvert B \rvert \begin{pmatrix}
+                              E & O \\
+                              O & E
+                          \end{pmatrix}.\]
+                      得到方程组
+                      \[\begin{cases}
+                              AX+CZ = \lvert A \rvert \lvert B \rvert E \\
+                              AY+CW = O                                 \\
+                              BZ    = O                                 \\
+                              BW    = \lvert A \rvert \lvert B \rvert E
+                          \end{cases}.\]
+                      考虑一般情况，我们不再单独讨论 $B$ 是否等于 $O$. 所以 $Z = O$, $X = \lvert B \rvert A^*$, $W = \lvert A \rvert B^*$, $Y = -A^*CB^*$. 即 \[\begin{pmatrix}
+                              A & C \\
+                              O & B
+                          \end{pmatrix}^* = \begin{pmatrix}
+                              \lvert B \rvert A^* & -A^*CB^*            \\
+                              O                   & \lvert A \rvert B^*
+                          \end{pmatrix}.\]
+
+                \item 若 $A$ 可逆，则可以通过以下的初等分块变换将其化为上三角块矩阵.
+                      \[\begin{pmatrix}
+                              E        & O \\
+                              -CA^{-1} & E
+                          \end{pmatrix} \begin{pmatrix}
+                              A & B \\
+                              C & D
+                          \end{pmatrix} = \begin{pmatrix}
+                              A & B          \\
+                              O & D-CA^{-1}B
+                          \end{pmatrix}.\]
+                      两侧取伴随有
+                      \begin{align*}
+                              & \left(\begin{pmatrix}
+                                              E        & O \\
+                                              -CA^{-1} & E
+                                          \end{pmatrix}
+                          \begin{pmatrix}
+                                  A & B \\
+                                  C & D
+                              \end{pmatrix}\right)^*
+                          = \begin{pmatrix}
+                                A & B \\
+                                C & D
+                            \end{pmatrix}^*
+                          \begin{pmatrix}
+                              E        & O \\
+                              -CA^{-1} & E
+                          \end{pmatrix}^*            \\
+                          ={} & \begin{pmatrix}
+                                    A & B          \\
+                                    O & D-CA^{-1}B
+                                \end{pmatrix}^*
+                          = \begin{pmatrix}
+                                \lvert D-CA^{-1}B \rvert A^* & -A^*B(D-CA^{-1}B)^*            \\
+                                O                            & \lvert A \rvert (D-CA^{-1}B)^*
+                            \end{pmatrix}
+                      \end{align*},
+                      而
+                      \[\begin{pmatrix}
+                              E        & O \\
+                              -CA^{-1} & E
+                          \end{pmatrix}^* \begin{pmatrix}
+                              E        & O \\
+                              -CA^{-1} & E
+                          \end{pmatrix} = \begin{vmatrix}
+                              E        & O \\
+                              -CA^{-1} & E
+                          \end{vmatrix} \begin{pmatrix}
+                              E & O \\
+                              O & E
+                          \end{pmatrix} = \begin{pmatrix}
+                              E & O \\
+                              O & E
+                          \end{pmatrix},\]
+                      所以
+                      \begin{align*}
+                              & \begin{pmatrix}
+                                    A & B \\
+                                    C & D
+                                \end{pmatrix}^*                                                                         \\
+                          ={} & \begin{pmatrix}
+                                    \lvert D-CA^{-1}B \rvert A^* & -A^*B(D-CA^{-1}B)^*            \\
+                                    O                            & \lvert A \rvert (D-CA^{-1}B)^*
+                                \end{pmatrix}
+                          \begin{pmatrix}
+                              E        & O \\
+                              -CA^{-1} & E
+                          \end{pmatrix}                                                                                \\
+                          ={} & \begin{pmatrix}
+                                    \lvert D-CA^{-1}B \rvert A^*+A^*B(D-CA^{-1}B)^*CA^{-1} & -A^*B(D-CA^{-1}B)^*            \\
+                                    -\lvert A \rvert (D-CA^{-1}B)^*CA^{-1}                 & \lvert A \rvert (D-CA^{-1}B)^*
+                                \end{pmatrix}. &
+                      \end{align*}
+            \end{enumerate}
+        \end{answer}
 
         \item 下面三个小问探讨伴随矩阵的反问题，即对任意给定的$n$阶方阵$B$，是否存在$n$阶方阵$A$使得$A^*=B$.
         \begin{enumerate}
@@ -2249,6 +3730,163 @@
                           1 & 1 & 1 \\ 1 & 1 & 1 \\ 1 & 1 & 1
                       \end{pmatrix}$，求矩阵$B$使得$B^*=A$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 因为 $n=2$ 时 $(A^*)^* = A$，所以 $B = (B^*)^* = A^*$，而 $B$ 的伴随矩阵是唯一的，所以存在唯一的2阶方阵 $A = B^*$ 使得 $A^* = B$.
+
+                \item $(\impliedby)$ 由 {例13.9(6)} 可得. % FIXME: xref
+
+                      $(\implies)$ \begin{enumerate}
+                          \item $r(B) = n$ 时，若存在 $A$ 使得 $A^* = B$，则由 $(A^*)^* = \lvert A \rvert^{n-2}A$，有
+                                \[A = \dfrac{1}{\lvert A \rvert^{n-2}}(A^*)^* = \dfrac{1}{\lvert A \rvert^{n-2}}B^* = \dfrac{1}{\lvert A \rvert^{n-2}}\lvert B \rvert B^{-1},\]
+                                而
+                                \[\lvert B \rvert = \lvert A^* \rvert = \lvert A \rvert^{n-1},\]
+                                代入上式可得
+                                \[A = \lvert A \rvert B^{-1} = \sqrt[n-1]{\lvert B \rvert} B^{-1}.\]
+                                从而满足 $A^* = B$ 的矩阵 $A$ 存在，且有 $n-1$ 个.
+
+                          \item $r(B) = 1$ 时，存在可逆矩阵 $P, Q$ 使得
+                                \[B = P\begin{pmatrix}
+                                        1 & O \\
+                                        O & O \\
+                                    \end{pmatrix}Q.\]
+                                若存在 $A$ 满足 $A^{*} = B$，则 $r(A) = n-1$，从而存在可逆矩阵 $G, H$ 使得
+                                \[A = G\begin{pmatrix}
+                                        0 & O       \\
+                                        O & E_{n-1}
+                                    \end{pmatrix}H,\]
+                                则
+                                \[A^* = H^*\begin{pmatrix}
+                                        0 & O       \\
+                                        O & E_{n-1}
+                                    \end{pmatrix}^*G^* = H^*\begin{pmatrix}
+                                        1 & O \\
+                                        O & O \\
+                                    \end{pmatrix}G^* = \lvert HG \rvert H^{-1}\begin{pmatrix}
+                                        1 & O \\
+                                        O & O \\
+                                    \end{pmatrix}G^{-1},\]
+                                由 $A^* = B$ 可得
+                                \[\lvert HG \rvert H^{-1}\begin{pmatrix}
+                                        1 & O \\
+                                        O & O \\
+                                    \end{pmatrix}G^{-1} = P\begin{pmatrix}
+                                        1 & O \\
+                                        O & O \\
+                                    \end{pmatrix}Q,\]
+                                即
+                                \[\lvert HG \rvert\begin{pmatrix}
+                                        1 & O \\
+                                        O & O \\
+                                    \end{pmatrix} = HP\begin{pmatrix}
+                                        1 & O \\
+                                        O & O \\
+                                    \end{pmatrix}QG,\]
+                                记 $C = HP$, $D = QG$，且分块为 $C = \begin{pmatrix}
+                                        C_{11} & C_{12} \\
+                                        C_{21} & C_{22}
+                                    \end{pmatrix}$, $D = \begin{pmatrix}
+                                        D_{11} & D_{12} \\
+                                        D_{21} & D_{22}
+                                    \end{pmatrix}$，其中 $C_{22}, D_{22}$ 是 $n-1$ 阶矩阵，则
+                                \[\lvert HG \rvert\begin{pmatrix}
+                                        1 & O \\
+                                        O & O \\
+                                    \end{pmatrix} = \begin{pmatrix}
+                                        C_{11} & C_{12} \\
+                                        C_{21} & C_{22}
+                                    \end{pmatrix} \begin{pmatrix}
+                                        1 & O \\
+                                        O & O \\
+                                    \end{pmatrix} \begin{pmatrix}
+                                        D_{11} & D_{12} \\
+                                        D_{21} & D_{22}
+                                    \end{pmatrix} = \begin{pmatrix}
+                                        C_{11}D_{11} & C_{11}D_{12} \\
+                                        C_{21}D_{11} & C_{21}D_{12}
+                                    \end{pmatrix},\]
+                                于是
+                                \[\lvert HG \rvert = C_{11}D_{11}, C_{11}D_{12} = O, C_{21}D_{11} = O, C_{21}D_{12} = O.\]
+                                因为 $H, G$ 可逆，所以 $C_{11} \neq 0, D_{11} \neq 0$，于是 $C_{21} = O = D_{12}$. 从而
+                                \begin{align*}
+                                    A & = G\begin{pmatrix}
+                                               0 & O       \\
+                                               O & E_{n-1}
+                                           \end{pmatrix}H
+                                    = Q^{-1}D\begin{pmatrix}
+                                                 0 & O       \\
+                                                 O & E_{n-1}
+                                             \end{pmatrix}CP^{-1}      \\
+                                      & = Q^{-1}\begin{pmatrix}
+                                                    D_{11} & O      \\
+                                                    D_{21} & D_{22}
+                                                \end{pmatrix}
+                                    \begin{pmatrix}
+                                        0 & O       \\
+                                        O & E_{n-1}
+                                    \end{pmatrix}
+                                    \begin{pmatrix}
+                                        C_{11} & C_{12} \\
+                                        O      & C_{22}
+                                    \end{pmatrix} P^{-1}               \\
+                                      & = Q^{-1} \begin{pmatrix}
+                                                     0 & O            \\
+                                                     O & D_{22}C_{22}
+                                                 \end{pmatrix} P^{-1}.
+                                \end{align*}
+                                又
+                                \[C_{11}D_{11} = \lvert HG \rvert = \lvert CP^{-1}Q^{-1}D \rvert = \dfrac{1}{\lvert PQ \rvert}\lvert DC \rvert.\]
+                                接下来转为求 $\lvert DC \rvert$. 而
+                                \[DC = \begin{pmatrix}
+                                        D_{11} & O      \\
+                                        D_{21} & D_{22}
+                                    \end{pmatrix} \begin{pmatrix}
+                                        C_{11} & C_{12} \\
+                                        O      & C_{22}
+                                    \end{pmatrix} = \begin{pmatrix}
+                                        D_{11}C_{11} & D_{11}C_{12}              \\
+                                        D_{21}C_{11} & D_{21}C_{12}+D_{22}C_{22}
+                                    \end{pmatrix}.\]
+                                考虑初等分块变换
+                                \begin{align*}
+                                    \begin{pmatrix}
+                                        1                  & O       \\
+                                        -D_{21}D_{11}^{-1} & E_{n-1}
+                                    \end{pmatrix}DC
+                                     & = \begin{pmatrix}
+                                             1                  & O       \\
+                                             -D_{21}D_{11}^{-1} & E_{n-1}
+                                         \end{pmatrix}
+                                    \begin{pmatrix}
+                                        D_{11}C_{11} & D_{11}C_{12}              \\
+                                        D_{21}C_{11} & D_{21}C_{12}+D_{22}C_{22}
+                                    \end{pmatrix} \\
+                                     & = \begin{pmatrix}
+                                             D_{11}C_{11} & D_{11}C_{12} \\
+                                             O            & D_{22}C_{22}
+                                         \end{pmatrix},
+                                \end{align*}
+                                故
+                                \[C_{11}D_{11} = \dfrac{1}{\lvert PQ \rvert}\lvert DC \rvert = \dfrac{1}{\lvert PQ \rvert}D_{11}C_{11} \lvert D_{22}C_{22} \rvert,\]
+                                从而
+                                \[\dfrac{1}{\lvert PQ \rvert} \lvert D_{22}C_{22} \rvert = 1,\]
+                                即
+                                \[\lvert D_{22}C_{22} \rvert = \lvert PQ \rvert.\]
+                                命题得证.
+
+                          \item $r(B) = 0$ 则是平凡情况，其是所有 $r \leqslant n-2$ 矩阵的伴随矩阵.
+                      \end{enumerate}
+
+                \item 由 $r(B^*) = r(A) = 1$ 可知 $r(B) = 2$. $B^*B = \lvert B \rvert E = 0$，由此可知 $B$ 的列向量为方程组 $B^*X = 0$ 的解，其基础解系为
+                      \[\alpha_1 = (-1, 1, 0)^{\mathrm{T}}, \alpha_2 = (-1, 0, 1)^{\mathrm{T}}.\]
+                      令 $B = (\alpha_1, \alpha_2, \alpha_3)$，其中 $\alpha_3 = k_1\alpha_1+k_2\alpha_2 = (k_1+k_2, -k_1, -k_2)^{\mathrm{T}}$. 由 $BB^* = 0$ 解得 $k_1 = k_2 = 1$，从而
+                      \[B = \begin{pmatrix}
+                              -1 & -1 & 2  \\
+                              1  & 0  & -1 \\
+                              0  & 1  & -1
+                          \end{pmatrix}.\]
+            \end{enumerate}
+        \end{answer}
 
         \item 证明$\begin{vmatrix}
                 a      & c      & c      & \cdots & c      \\
@@ -2257,6 +3895,20 @@
                 \vdots & \vdots & \vdots & \ddots & \vdots \\
                 b      & b      & b      & \cdots & a
             \end{vmatrix}=\dfrac{b(a-c)^{n}-c(a-b)^{n}}{b-c}$，其中 $b \neq c$, 等式左端是 $n$ 阶行列式.
+        \begin{answer}
+            我们将第 $i$ 行乘 $(-1)$ 加到第 $i-1$ 行（$i$ 依次取 $n, n-1, \ldots, 2$），再对第 1 列展开,
+            \[D_{n}=\begin{vmatrix}
+                    a-b    & c-a    & 0      & \cdots & 0      \\
+                    0      & a-b    & c-a    & \cdots & 0      \\
+                    \vdots & \vdots & \vdots & \ddots & \vdots \\
+                    0      & 0      & 0      & \cdots & c-a    \\
+                    b      & b      & b      & \cdots & a
+                \end{vmatrix}=(a-b)D_{n-1}+(-1)^{n+1}b(c-a)^{n-1},\]
+            有了递推式，但是递推式中有$(-1)^{n+1}$，递推比较麻烦可能还需要处理. 如果用数归证明的话应该可以直接下手了，但是有更聪明的办法：取转置，则行列式的值不变，但是 $b$ 与 $c$ 的位置交换，由此可以写出 $D_n$ 的第二个递推式：$D_n=(a-c)D_{n-1}+(-1)^{n+1}c(b-a)^{n-1}$. 两个递推式分别乘以 $a-c$ 与 $a-b$ 后相减即有
+            \[
+                D_n=\dfrac{b(a-c)^{n}-c(a-b)^{n}}{b-c}.
+            \]
+            \end{answer}
 
         \item 计算$n$阶行列式
         \[|A|=\begin{vmatrix}
@@ -2266,6 +3918,21 @@
                 \vdots & \vdots & \vdots & \ddots & \vdots \\
                 a_nb_1 & a_nb_2 & a_nb_3 & \cdots & a_nb_n
             \end{vmatrix}.\]
+        \begin{answer}
+            \begin{enumerate}
+                \item $n=1$ 时，显然有 $|A|=a_1b_1$.
+
+                \item $n \geqslant 2$ 时，
+                    \[
+                        A = \begin{pmatrix}
+                            a_1 \\ a_2 \\ \vdots \\ a_n
+                        \end{pmatrix} \begin{pmatrix}
+                            b_1 & b_2 & \cdots & b_n
+                        \end{pmatrix},
+                    \]
+                    故 $r(A) = 1 < n$，$A$ 不可逆，因此 $|A| = 0$.
+            \end{enumerate}
+        \end{answer}
 
         \item 计算$n$阶行列式
         \[|A|=\begin{vmatrix}
@@ -2274,6 +3941,49 @@
                 \vdots  & \vdots  & \ddots & \vdots  \\
                 a_na_1  & a_na_2  & \cdots & 1+a_n^2
             \end{vmatrix}.\]
+        \begin{answer}
+            设
+            \[
+                D_n = \begin{vmatrix}
+                    1+a_1^2 & a_1a_2  & \cdots & a_1a_n  \\
+                    a_2a_1  & 1+a_2^2 & \cdots & a_2a_n  \\
+                    \vdots  & \vdots  & \ddots & \vdots  \\
+                    a_na_1  & a_na_2  & \cdots & 1+a_n^2
+                \end{vmatrix},
+            \]
+
+            利用行列式公理化定义中的线性性，有
+            \begin{align*}
+                D_n &= \begin{vmatrix}
+                    1+a_1^2 & a_1a_2  & \cdots & a_1a_n  \\
+                    a_2a_1  & 1+a_2^2 & \cdots & a_2a_n  \\
+                    \vdots  & \vdots  & \ddots & \vdots  \\
+                    a_na_1  & a_na_2  & \cdots & a_n^2
+                \end{vmatrix} + \begin{vmatrix}
+                    1+a_1^2 & a_1a_2  & \cdots & 0       \\
+                    a_2a_1  & 1+a_2^2 & \cdots & 0       \\
+                    \vdots  & \vdots  & \ddots & \vdots  \\
+                    a_na_1  & a_na_2  & \cdots & 1
+                \end{vmatrix} \\
+                &= a_n \begin{vmatrix}
+                    1+a_1^2 & a_1a_2  & \cdots & a_1     \\
+                    a_2a_1  & 1+a_2^2 & \cdots & a_2     \\
+                    \vdots  & \vdots  & \ddots & \vdots  \\
+                    a_na_1  & a_na_2  & \cdots & a_n
+                \end{vmatrix} + D_{n-1} \\
+                &= a_n \begin{vmatrix}
+                    1      & 0      & \cdots & a_1     \\
+                    0      & 1      & \cdots & a_2     \\
+                    \vdots & \vdots & \ddots & \vdots  \\
+                    0      & 0      & \cdots & a_n
+                \end{vmatrix} \\
+                &= D_{n-1} + a_n^2.
+            \end{align*}
+            而 $D_1 = 1 + a_1^2$, 因此
+            \[
+                |A| = D_n = 1 + \sum_{i=1}^n a_i^2.
+            \]
+        \end{answer}
 
         \item 计算$n$阶行列式
         \[|A|=\begin{vmatrix}
@@ -2282,6 +3992,86 @@
                 \vdots & \vdots  & \ddots & \vdots  \\
                 1+x_n  & 1+x_n^2 & \cdots & 1+x_n^n
             \end{vmatrix}.\]
+        \begin{answer}
+            使用硬拆法，将 $A$ 的第 $i$ 行分解为 $(1, 1, \ldots, 1) + (x_i, x_i^2, \ldots, x_i^n)$. 考虑到拆出的行列式中包含不少于两列为 $(1, 1, \ldots, 1)$ 的项均为 $0$，因此可将 $|A|$ 化简为
+            \[
+                \begin{vmatrix}
+                    x_1    & x_1^2  & \cdots & x_1^n  \\
+                    x_2    & x_2^2  & \cdots & x_2^n  \\
+                    \vdots & \vdots & \ddots & \vdots \\
+                    x_n    & x_n^2  & \cdots & x_n^n
+                \end{vmatrix} + \sum_{j=1}^n \begin{vmatrix}
+                    x_1     & x_1^2     & \cdots & x_1^n     \\
+                    \vdots  & \vdots    &        & \vdots    \\
+                    x_{i-1} & x_{i-1}^2 & \cdots & x_{i-1}^n \\
+                    1       & 1         & \cdots & 1         \\
+                    x_{i+1} & x_{i+1}^2 & \cdots & x_{i+1}^n \\
+                    \vdots  & \vdots    &        & \vdots    \\
+                    x_n     & x_n^2     & \cdots & x_n^n
+                \end{vmatrix}.
+            \]
+
+            上式中第一项可利用 Vandermonde 行列式化简：
+            \[
+                \begin{vmatrix}
+                    x_1    & x_1^2  & \cdots & x_1^n  \\
+                    x_2    & x_2^2  & \cdots & x_2^n  \\
+                    \vdots & \vdots & \ddots & \vdots \\
+                    x_n    & x_n^2  & \cdots & x_n^n
+                \end{vmatrix} = \prod_{i=1}^n x_i \begin{vmatrix}
+                    1      & x_1    & x_1^2  & \cdots & x_1^n  \\
+                    1      & x_2    & x_2^2  & \cdots & x_2^n  \\
+                    \vdots & \vdots & \vdots & \ddots & \vdots \\
+                    1      & x_n    & x_n^2  & \cdots & x_n^n
+                \end{vmatrix} = \left(\prod_{i=1}^n x_i\right) \left(\prod_{1 \leqslant i < j \leqslant n} (x_j - x_i)\right).
+            \]
+
+            对于第二项，
+            \begin{align*}
+                \begin{vmatrix}
+                    x_1     & x_1^2     & \cdots & x_1^n     \\
+                    \vdots  & \vdots    &        & \vdots    \\
+                    x_{i-1} & x_{i-1}^2 & \cdots & x_{i-1}^n \\
+                    1       & 1         & \cdots & 1         \\
+                    x_{i+1} & x_{i+1}^2 & \cdots & x_{i+1}^n \\
+                    \vdots  & \vdots    &        & \vdots    \\
+                    x_n     & x_n^2     & \cdots & x_n^n
+                \end{vmatrix}
+                &= \begin{vmatrix}
+                    x_1     & x_1 (x_1-1)         & \cdots & x_1^{n-1} (x_1-1)         \\
+                    \vdots  & \vdots              &        & \vdots                    \\
+                    x_{i-1} & x_{i-1} (x_{i-1}-1) & \cdots & x_{i-1}^{n-1} (x_{i-1}-1) \\
+                    1       & 0                   & \cdots & 0                         \\
+                    x_{i+1} & x_{i+1} (x_{i+1}-1) & \cdots & x_{i+1}^{n-1} (x_{i+1}-1) \\
+                    \vdots  & \vdots              &        & \vdots                    \\
+                    x_n     & x_n (x_n-1)         & \cdots & x_n^{n-1} (x_n-1)
+                \end{vmatrix} \\
+                &= \begin{vmatrix}
+                    x_1-1     & x_1 (x_1-1)         & \cdots & x_1^{n-1} (x_1-1)         \\
+                    \vdots    & \vdots              &        & \vdots                    \\
+                    x_{i-1}-1 & x_{i-1} (x_{i-1}-1) & \cdots & x_{i-1}^{n-1} (x_{i-1}-1) \\
+                    1         & 0                   & \cdots & 0                         \\
+                    x_{i+1}-1 & x_{i+1} (x_{i+1}-1) & \cdots & x_{i+1}^{n-1} (x_{i+1}-1) \\
+                    \vdots    & \vdots              &        & \vdots                    \\
+                    x_n-1     & x_n (x_n-1)         & \cdots & x_n^{n-1} (x_n-1)
+                \end{vmatrix} \\
+                &= (-1)^{i+1} \prod_{j \neq i} (x_j - 1) \begin{vmatrix}
+                    1      & x_1     & \cdots & x_1^{n-1}     \\
+                    \vdots & \vdots  &        & \vdots        \\
+                    1      & x_{i-1} & \cdots & x_{i-1}^{n-1} \\
+                    1      & x_{i+1} & \cdots & x_{i-1}^{n+1} \\
+                    \vdots & \vdots  &        & \vdots        \\
+                    1      & x_n     & \cdots & x_n^{n-1}
+                \end{vmatrix} \\
+                &= (-1)^{i+1} \prod_{j \neq i} \frac{x_j - 1}{x_j - x_i} \prod_{1 \leqslant k < j \leqslant n} (x_j - x_k).
+            \end{align*}
+
+            综上可得，
+            \[
+                |A| = \left( \prod_{i=1}^n x_i + \sum_{i=1}^n (-1)^{i+1} \prod_{j \neq i} \frac{x_j - 1}{x_j - x_i} \right) \prod_{1 \leqslant i < j \leqslant n} (x_j - x_i).
+            \]
+
+        \end{answer}
 
         \item 计算$n$阶行列式，其中$x,y,z$为任意实常数：
         \[|A|=\begin{vmatrix}
@@ -2291,5 +4081,81 @@
                 \vdots & \vdots & \vdots & \ddots & \vdots \\
                 z      & z      & z      & \cdots & x_n
             \end{vmatrix}.\]
+        \begin{answer}
+            \begin{enumerate}
+                \item 若 $y = z$，
+                    则
+                    \[
+                        |A| = \begin{vmatrix}
+                            x_1    & y      & y      & \cdots & y      \\
+                            y      & x_2    & y      & \cdots & y      \\
+                            y      & y      & x_3    & \cdots & y      \\
+                            \vdots & \vdots & \vdots & \ddots & \vdots \\
+                            y      & y      & y      & \cdots & x_n
+                        \end{vmatrix}.
+                    \]
+
+                    \begin{enumerate}
+                        \item 若存在 $i \neq j$，使得 $x_i = x_j = y$，则 $A$ 中有两列元素全为 $y$，因此 $|A|$ 为 $0$.
+
+                        \item 若存在唯一 $i$，使得 $x_i = y$，则
+                            \begin{align*}
+                                |A| &= (-1)^{i - 1 + i - 1} \begin{vmatrix}
+                                    x_i    & y      & y      & \cdots & y      \\
+                                    y      & x_1    & y      & \cdots & y      \\
+                                    y      & y      & x_2    & \cdots & y      \\
+                                    \vdots & \vdots & \vdots & \ddots & \vdots \\
+                                    y      & y      & y      & \cdots & x_n
+                                \end{vmatrix} \\
+                                &= \begin{vmatrix}
+                                    y      & y       & y       & \cdots & y       \\
+                                    0      & x_1 - y & 0       & \cdots & 0       \\
+                                    0      & 0       & x_2 - y & \cdots & 0       \\
+                                    \vdots & \vdots  & \vdots  & \ddots & \vdots  \\
+                                    0      & 0       & 0       & \cdots & x_n - y
+                                \end{vmatrix} \\
+                                &= y \prod_{j \neq i} (x_j - y).
+                            \end{align*}
+
+                            \item 若不存在 $i$，使得 $x_i = y$，则
+                                \begin{align*}
+                                    |A| &= \begin{vmatrix}
+                                        1      & y      & y      & y      & \cdots & y      \\
+                                        0      & x_1    & y      & y      & \cdots & y      \\
+                                        0      & y      & x_2    & y      & \cdots & y      \\
+                                        0      & y      & y      & x_3    & \cdots & y      \\
+                                        \vdots & \vdots & \vdots & \vdots & \ddots & \vdots \\
+                                        0      & y      & y      & y      & \cdots & x_n
+                                    \end{vmatrix}_{n+1} \\
+                                    &= \begin{vmatrix}
+                                        1      & y      & y      & y      & \cdots & y      \\
+                                        -1     & x_1-y  & 0      & 0      & \cdots & 0      \\
+                                        -1     & 0      & x_2-y  & 0      & \cdots & 0      \\
+                                        -1     & 0      & 0      & x_3-y  & \cdots & 0      \\
+                                        \vdots & \vdots & \vdots & \vdots & \ddots & \vdots \\
+                                        -1     & 0      & 0      & 0      & \cdots & x_n-y
+                                    \end{vmatrix}_{n+1} \\
+                                    &= \begin{vmatrix}
+                                        1 + \sum_{j=1}^n \frac{y}{x_j-y} & y      & y      & y      & \cdots & y      \\
+                                        0                                & x_1-y  & 0      & 0      & \cdots & 0      \\
+                                        0                                & 0      & x_2-y  & 0      & \cdots & 0      \\
+                                        0                                & 0      & 0      & x_3-y  & \cdots & 0      \\
+                                        \vdots                           & \vdots & \vdots & \vdots & \ddots & \vdots \\
+                                        0                                & 0      & 0      & 0      & \cdots & x_n-y
+                                    \end{vmatrix} \\
+                                    &= \prod_{j=1}^n (x_j - y) + y\sum_{i=1}^n \prod_{j \neq i} (x_j - y).
+                                \end{align*}
+                    \end{enumerate}
+                    综上，当 $y = z$ 时，
+                    \[
+                        |A| = \prod_{j=1}^n (x_j - y) + y\sum_{i=1}^n \prod_{j \neq i} (x_j - y).
+                    \]
+
+                \item 若 $y \neq z$，则可按照与第 10 题完全相同的方法进行处理，最后得到
+                    \[
+                        |A| = \frac{z \prod_{i=1}^n (x_i - y) - y \prod_{i=1}^n (x_i - z)}{z - y}.
+                    \]
+            \end{enumerate}
+        \end{answer}
     \end{exgroup}
 \end{exercise}

--- a/讲义/专题/12 行列式.tex
+++ b/讲义/专题/12 行列式.tex
@@ -6,7 +6,7 @@
 
 \section{行列式的定义}
 
-或许行列式是线性代数基础内容中最难下定义的一个概念了——不同的教材通常会给出不同的行列式引入和定义方式，且不同的思路各有其优劣。通常有三种基本的定义方式：``逆序数''定义（最常见的方式）、递归式定义（按行（列）展开）以及公理化定义（使用一些规则描述），这三种定义方式也是完全等价的. 在本讲中，我们从公理化定义出发，将递归式定义作为性质进行介绍，然后在行列式的基本运算中引入逆序数定义. 在读者已经适应公理化定义的体系后，我想这样的思路更具有几何直观，很多的推导也非常便捷.
+或许行列式是线性代数基础内容中最难下定义的一个概念了——不同的教材通常会给出不同的行列式引入和定义方式，且不同的思路各有其优劣. 通常有三种基本的定义方式：``逆序数''定义（最常见的方式）、递归式定义（按行（列）展开）以及公理化定义（使用一些规则描述），这三种定义方式也是完全等价的. 在本讲中，我们从公理化定义出发，将递归式定义作为性质进行介绍，然后在行列式的基本运算中引入逆序数定义. 在读者已经适应公理化定义的体系后，我想这样的思路更具有几何直观，很多的推导也非常便捷.
 
 \subsection{公理化定义}
 
@@ -41,7 +41,8 @@
 
         \item 对行列式做倍加列变换，行列式的值不变.
 
-        \item 若$\alpha_1,\alpha_2,\ldots,\alpha_n$线性相关，则$D(\alpha_1,\alpha_2,\ldots,\alpha_n)=0$.
+        \item \label{item:13:公理化定义导出性质:5}
+            若$\alpha_1,\alpha_2,\ldots,\alpha_n$线性相关，则$D(\alpha_1,\alpha_2,\ldots,\alpha_n)=0$.
     \end{enumerate}
 \end{example}
 
@@ -66,7 +67,7 @@
                   D(\alpha_1,\ldots,\alpha_i,\ldots,\alpha_j,\ldots,\alpha_n)
                    & =D(\alpha_1,\ldots,k\alpha_j,\ldots,\alpha_j,\ldots,\alpha_n) \\
                    & =kD(\alpha_1,\ldots,\alpha_j,\ldots,\alpha_j,\ldots,\alpha_n) \\
-                   & =0
+                   & =0.
               \end{align*}
               其中最后一个等号用到了本例的第二条结论.
 
@@ -199,34 +200,76 @@
     \item 一般情况下，$|A \pm B| \neq |A|\pm|B|$；
 
     \item $|kA|=k^n|A|$；
-          \begin{proof}
-              由\autoref{def:公理化定义} 的\ref*{item:13:齐性}，设$A=(\alpha_1,\alpha_2,\ldots,\alpha_n)$，则
-              \begin{align*}
-                  |kA| & =|k\alpha_1,k\alpha_2,\ldots,k\alpha_n| \\
-                       & =k^n|\alpha_1,\alpha_2,\ldots,\alpha_n| \\
-                       & =k^n|A|.
-              \end{align*}
-          \end{proof}
 
-    \item \label{item:13:行列式性质:4}
+    \item \label{item:13:行列式性质:3}
           初等矩阵行列式（注意初等矩阵不分行列，左乘右乘区分初等行列变换）：\\
           $|E_{ij}|=-1,\enspace |E_i(c)|=c,\enspace |E_{ij}(k)|=1$；
 
-    \item 利用 \ref*{item:13:行列式性质:4} 中的结论可以得到$|AB|=|A||B|,\enspace|A^k|=|A|^k$；
+    \item \label{item:13:行列式性质:4}
+          $|AB|=|A||B|,\enspace|A^k|=|A|^k$；
 
-    \item 利用 \ref*{item:13:行列式性质:4} 中的结论可以得到$A$可逆$\iff |A| \neq 0$；
+    \item $A$可逆$\iff |A| \neq 0$；
 
-    \item 利用 \ref*{item:13:行列式性质:4} 中的结论可以得到$|A^\mathrm{T}|=|A|$；
+    \item $|A^\mathrm{T}|=|A|$；
 
-    \item 利用 \ref*{item:13:行列式性质:4} 中的结论可以得到上、下三角矩阵行列式均为主对角线元素的乘积；
+    \item 上、下三角矩阵行列式均为主对角线元素的乘积；
 
-    \item 利用 \ref*{item:13:行列式性质:4} 中的结论（求出初等矩阵逆矩阵行列式）可以得到若$A$可逆，则$|A^{-1}|=|A|^{-1}$.
-          \begin{proof}
-              由$|AB|=|A||B|$，设$B=A^{-1}$，则$|E|=|AA^{-1}|=|A||A^{-1}|$，因此$|A||A^{-1}|=1$，从而$|A^{-1}|=|A|^{-1}$.
-          \end{proof}
+    \item 若$A$可逆，则$|A^{-1}|=|A|^{-1}$.
+
 \end{enumerate}
 
-以上性质都可以基于定义或上述其他性质得到，其中3-6条可参考教材5.3节，7可参考教材172页例3. 这些性质结论希望读者熟悉，实际上推导过程重要性不大，虽然也并不复杂. 下面介绍的性质需要用到``打洞法''（分块矩阵初等变换）来证明：
+\begin{proof}
+    \begin{enumerate}[start=2]
+        \item 由\autoref{def:公理化定义} 的\ref*{item:13:齐性}，设$A=(\alpha_1,\alpha_2,\ldots,\alpha_n)$，则
+        \begin{align*}
+            |kA| & =|k\alpha_1,k\alpha_2,\ldots,k\alpha_n| \\
+                 & =k^n|\alpha_1,\alpha_2,\ldots,\alpha_n| \\
+                 & =k^n|A|.
+        \end{align*}
+
+        \item 设 $E = (e_1, e_2, \ldots, e_n)$，则
+
+            由\autoref{def:公理化定义} 的\ref*{item:13:反对称性}，$|E_{ij}| = |e_1, e_2, \ldots, e_j, \ldots, e_i, \ldots, e_n| = -|E| = -1$；
+
+            由\autoref{def:公理化定义} 的\ref*{item:13:齐性}，$|E_i(c)| = |e_1, e_2, \ldots, c e_i, \ldots, e_n| = c|E| = c$；
+
+            由\autoref{def:公理化定义} 的\ref*{item:13:加性}，$|E_{ij}(k)| = |e_1, e_2, \ldots, e_i + k e_j, \ldots, e_n| = |E| + 0 = 1$.
+
+        \item 对于 $|AB| = |A||B|$，分 $B$ 可逆与不可逆两种情况讨论：
+
+            若 $B$ 可逆，则存在初等矩阵 $P_1, P_2, \ldots, P_k$，使得 $B = P_1 P_2 \cdots P_k$；由于右乘初等矩阵相当于对矩阵进行初等列变换，因此我们利用\ref*{item:13:行列式性质:3} 中的结论可以得到
+            \begin{align*}
+                |A E_ij| = -|A| = |A||E_ij|, \\
+                |A E_i(c)| = c|A| = c|A||E_i(c)|, \\
+                |A E_{ij}(k)| = |A| = |A||E_{ij}(k)|.
+            \end{align*}
+            因此，$|AB| = |A P_1 P_2 \cdots P_k| = |A||P_1||P_2|\cdots||P_k| = |A||B|$.
+
+            若 $B$ 不可逆，则 $r(AB) \leqslant r(B) < n$，故 $AB$ 也不可逆. 组成不可逆的矩阵的列向量必线性相关，故由\autoref{ex:公理化定义} 的\ref*{item:13:公理化定义导出性质:5} 可知 $|B|=0, |AB|=0$，因此 $|AB| = 0 = |A||B|$.
+
+            同理，分 $A$ 可逆与不可逆两种情况讨论，可得 $|A^k|=|A|^k$.
+
+        \item 若 $A$ 可逆，则存在可逆矩阵 $B$ 使得 $AB=E$，利用性质\ref*{item:13:行列式性质:4} 可知 $|A||B|=|E|=1$，故 $|A| \neq 0$. 反之，若 $A$ 不可逆，则 $A$ 的列向量线性相关，故 $|A| = 0$.
+
+        \item 若 $A$ 不可逆，则 $A^\mathrm{T}$ 不可逆，故 $|A| = |A^\mathrm{T}| = 0$；
+            若 $A$ 可逆，则存在初等矩阵 $P_1, P_2, \ldots, P_k$，使得 $A = P_1 P_2 \cdots P_k$，故
+            \begin{align*}
+                |A^\mathrm{T}| &= |P_k^\mathrm{T} P_{k-1}^\mathrm{T} \cdots P_1^\mathrm{T}| \\
+                      &= |P_k^\mathrm{T}| |P_{k-1}^\mathrm{T}| \cdots |P_1^\mathrm{T}| \\
+                      &= |P_k| |P_{k-1}| \cdots |P_1| \\
+                      &= |A|.
+            \end{align*}
+            上式成立是因为三类初等矩阵的行列式等于其转置的行列式.
+
+        \item 设 $A$ 为上三角矩阵，其对角线元素为 $a_{11}, a_{22}, \ldots, a_{nn}$，若 $\exists a_{ii} = 0$，则 $A$ 不可逆，$|A| = 0$；反之，若 $a_{ii} \neq 0, \enspace i=1,2,\ldots,n$，则对 $A$ 作倍加列变换可将 $A$ 化为对角矩阵 $\mathrm{diag}(a_{11},a_{22},\ldots,a_{nn})$，故 $|A| = \prod_{i=1}^n a_{ii}$.
+
+            若 $A$ 为下三角矩阵，则 $A^\mathrm{T}$ 为上三角矩阵，故 $|A| = |A^\mathrm{T}| = \prod_{i=1}^n a_{ii}$.
+
+        \item 由$|AB|=|A||B|$，设$B=A^{-1}$，则$|E|=|AA^{-1}|=|A||A^{-1}|$，因此$|A||A^{-1}|=1$，从而$|A^{-1}|=|A|^{-1}$.
+    \end{enumerate}
+\end{proof}
+
+以上这些性质希望读者熟悉，实际上推导过程重要性不大，基于定义或上述其他性质便可以得到这些结论. 下面介绍的性质需要用到``打洞法''（分块矩阵初等变换）来证明：
 
 \begin{enumerate}
     \item $\begin{vmatrix}
@@ -238,8 +281,103 @@
               \end{vmatrix} = |A||B|,\enspace\begin{vmatrix}
                   O & A \\ B & C
               \end{vmatrix} = (-1)^{kr}|A||B|$（其中$A$为$k$阶方阵，$B$为$r$阶方阵）；
+
+          我们先给出使用数学归纳法证明的思路：
           \begin{proof}
-              证明从略，感兴趣的读者可以参考教材179页例2，实际上我们很多时候只需要基于这些结论证明进一步的性质.
+            先证明 $\begin{vmatrix}
+                        A & O \\ C & B
+                    \end{vmatrix} = |A||B|$. 我们令
+            \[
+                D = \begin{vmatrix}
+                        A & O \\ C & B
+                    \end{vmatrix} = \begin{vmatrix}
+                        a_{11} & a_{12} & \cdots & a_{1k} & 0      & \cdots & 0      \\
+                        a_{21} & a_{22} & \cdots & a_{2k} & 0      & \cdots & 0      \\
+                        \vdots &        & \ddots & \vdots & \vdots &        & \vdots \\
+                        a_{k1} & a_{k2} & \cdots & a_{kk} & 0      & \cdots & 0      \\
+                        c_{11} & c_{12} & \cdots & c_{1k} & b_{11} & \cdots & b_{1r} \\
+                        \vdots &        &        & \vdots & \vdots & \ddots & \vdots \\
+                        c_{r1} & c_{r2} & \cdots & c_{rk} & b_{r1} & \cdots & b_{rr}
+                    \end{vmatrix}.
+            \]
+            对 $A$ 的阶数 $k$ 作数学归纳法：当 $k=1$ 时，$D = a_{11}|B| = |A||B|$ 是显然的；假设 $A$ 的阶数为 $k-1$ 时上述结论成立，则当 $A$ 的阶数为 $k$ 时，我们对 $D$ 的第一行展开，得
+            \[
+                D = (-1)^{1+1} a_{11} M_{11}^D + (-1)^{1+2} a_{12} M_{12}^D + \cdots + (-1)^{1+k} a_{1k} M_{1k}^D,
+            \]
+            其中 $M_{1j}^D$ 是 $a_{1j}$ 在 $D$ 中的余子式.
+            注意到 $M_{1j}^D$ 仍然是 $\begin{vmatrix}
+                A & O \\ C & B
+            \end{vmatrix}$ 类型的行列式，故由归纳假设我们有
+            \[
+                M_{1j}^D = M_{1j}^A |B|, \enspace j = 1, 2, \ldots, k.
+            \]
+            其中 $M_{1j}^A$ 是 $a_{1j}$ 在 $A$ 中的余子式. 将其代入 $D$ 的展开式，得到
+            \[
+                D = \left[(-1)^{1+1} a_{11} M_{11}^A + (-1)^{1+2} a_{12} M_{12}^A + \cdots + (-1)^{1+k} a_{1k} M_{1k}^A\right] |B| = |A||B|.
+            \]
+
+            根据以上结论，令 $C = O$，则有
+            \[
+                \begin{vmatrix} A & O \\ O & B \end{vmatrix} = |A||B|.
+            \]
+
+            利用 $|A^\mathrm{T}|=|A|$，有
+            \[
+                \begin{vmatrix}
+                    A & C \\ O & B
+                \end{vmatrix} = \begin{vmatrix}
+                    A^\mathrm{T} & O \\ C^\mathrm{T} & B^\mathrm{T}
+                \end{vmatrix} = |A^\mathrm{T}||B^\mathrm{T}| = |A||B|.
+            \]
+
+            由于从 $\begin{vmatrix} O & A \\ B & C \end{vmatrix}$ 到 $\begin{vmatrix} A & C \\ O & B \end{vmatrix}$ 只需将 $A$ 和 $C$ 中的每一列依次与前面的 $r$ 列逐列交换，利用\autoref{def:公理化定义} 的\ref*{item:13:反对称性}，我们有
+            \[
+                \begin{vmatrix}
+                    O & A \\ B & C
+                \end{vmatrix} = (-1)^{kr} \begin{vmatrix}
+                    A & O \\ C & B
+                \end{vmatrix} = (-1)^{kr} |A||B|.
+            \]
+          \end{proof}
+
+          下面我们使用打洞法来重新证明，可以发现，使用打洞法可以使证明变得更为简洁：
+          \begin{proof}
+              若 $B$ 不可逆，则 $r(B) < r$，故 $r\begin{pmatrix} O \\ B \end{pmatrix} < r$，进而 $r\begin{pmatrix} A & O \\ C & B \end{pmatrix} < k + r$，故
+              \[
+                  \begin{vmatrix}
+                      A & O \\ C & B
+                  \end{vmatrix} = 0 = |A||B|.
+              \]
+
+              若 $B$ 可逆，则
+              \[
+                  \begin{pmatrix}
+                      A & O \\ C & B
+                  \end{pmatrix} \begin{pmatrix}
+                      E_k & O \\ -B^{-1} C & E_r
+                  \end{pmatrix} = \begin{pmatrix}
+                      A & O \\ O & B
+                  \end{pmatrix} = \begin{pmatrix}
+                      A & O \\ O & E_r
+                  \end{pmatrix} \begin{pmatrix}
+                      E_k & O \\ O & B
+                  \end{pmatrix},
+              \]
+              而分块倍加矩阵的行列式
+              \[
+                  \begin{vmatrix}
+                      E_k & O \\ -B^{-1} C & E_r
+                  \end{vmatrix} = 1,
+              \]
+              故有
+              \[
+                  \begin{vmatrix}
+                      A & O \\ C & B
+                  \end{vmatrix} = \begin{vmatrix}
+                      A & O \\ O & B
+                  \end{vmatrix} = |A||B|.
+              \]
+              其余推导部分同上.
           \end{proof}
 
     \item 当$A$可逆时，有$\begin{vmatrix}
@@ -299,7 +437,7 @@
                       a_1 & 1 \\ a_2 & 1 \\ \vdots & \vdots \\ a_n & 1
                   \end{pmatrix} E_2^{-1} \begin{pmatrix}
                       a_1 & a_2 & \cdots & a_n \\ 1 & 1 & \cdots & 1
-                  \end{pmatrix} \]
+                  \end{pmatrix}. \]
 
               故根据降阶公式有
 
@@ -361,9 +499,48 @@
 
 \begin{solution}
     \begin{enumerate}
-        \item （公理化定义与性质）参考教材171页例2的方法，此处展开较为复杂不再赘述，也不推荐使用这一方法.
+        \item （公理化定义与性质）由\autoref{def:公理化定义} 对该行列式进行展开操作（此处略去展开后有相同列向量的项），得到
+            \begin{align*}
+                D =&\, \begin{vmatrix}
+                    e_1 + 2e_2 + 3e_3 & 2e_1 + 3e_2 + e_3 & 3e_1 + e_2 + 2e_3
+                \end{vmatrix} \\
+                =&\, \begin{vmatrix}
+                    e_1 & 3e_2 & 2e_3
+                \end{vmatrix} + \begin{vmatrix}
+                    e_1 & e_3 & e_2
+                \end{vmatrix} + \begin{vmatrix}
+                    2e_2 & 2e_1 & 2e_3
+                \end{vmatrix} + \\
+                &\, \begin{vmatrix}
+                    2e_2 & e_3 & 3e_1
+                \end{vmatrix} + \begin{vmatrix}
+                    3e_3 & 2e_1 & e_2
+                \end{vmatrix} + \begin{vmatrix}
+                    3e_3 & 3e_2 & 3e_1
+                \end{vmatrix} \\
+                =&\, 1 \cdot 3 \cdot 2 - 1 \cdot 1 \cdot 1 - 2 \cdot 2 \cdot 2 + 2 \cdot 1 \cdot 3 + 3 \cdot 2 \cdot 1 - 3 \cdot 3 \cdot 3 \\
+                =&\, -18.
+            \end{align*}
+            使用公理化定义展开行列式十分复杂，因此在实际运用中不推荐使用这一方法.
 
-        \item （化为上三角形式）参考教材172页例4，具体过程不在此展开.
+        \item （化为上三角形式）对 $D$ 作初等行变换，将其化为上三角行列式：
+            \[
+                D = \begin{vmatrix}
+                    1 & 2 & 3 \\
+                    2 & 3 & 1 \\
+                    3 & 1 & 2
+                \end{vmatrix} = \begin{vmatrix}
+                    1 & 2 & 3 \\
+                    0 & -1 & -5 \\
+                    0 & -5 & -7
+                \end{vmatrix} = \begin{vmatrix}
+                    1 & 2 & 3 \\
+                    0 & -1 & -5 \\
+                    0 & 0 & 18
+                \end{vmatrix}
+                = 1 \cdot (-1) \cdot 18
+                = -18.
+            \]
 
         \item （递归式定义展开）我们对第一行展开，由\autoref{def:递归式定义} 可知
               \begin{align*}
@@ -520,7 +697,7 @@
             x_1       & x_2       & \cdots & x_n       \\
             \vdots    & \vdots    & \ddots & \vdots    \\
             x_1^{n-1} & x_2^{n-1} & \cdots & x_n^{n-1}
-        \end{vmatrix}=\prod_{1 \leqslant i < j \leqslant n}(x_j-x_i)\]
+        \end{vmatrix}=\prod_{1 \leqslant i < j \leqslant n}(x_j-x_i).\]
 \end{example}
 
 \begin{proof}
@@ -539,7 +716,7 @@
             0      & x_2^2     & \cdots & x_n^2     \\
             \vdots & \vdots    & \ddots & \vdots    \\
             0      & x_2^{n-2} & \cdots & x_n^{n-2}
-        \end{vmatrix}
+        \end{vmatrix}.
     \end{align*}
     上式右端为是关于$x_2,x_3,\ldots,x_n$的$n-1$阶范德蒙行列式，根据归纳假设，我们有
     \begin{align*}
@@ -557,24 +734,22 @@
     设$\dim V=n$，设$\alpha_1,\alpha_2,\ldots,\alpha_n$为$V$的一组基，构造向量组$\{\beta_k\}$中每个元素满足
     \[\beta_k=\alpha_1+k\alpha_2+\cdots+k^{n-1}\alpha_n,\enspace k=1,2,3,\ldots\]
     任取上述向量组中的$n$个向量$\beta_{k_1},\beta_{k_2},\ldots,\beta_{k_n}$，其中$k_1<k_2<\cdots<k_n$，则有
-    \[(\beta_{k_1},\beta_{k_2},\ldots,\beta_{k_n})=(\alpha_1,\alpha_2,\ldots,\alpha_n)C\]
+    \[(\beta_{k_1},\beta_{k_2},\ldots,\beta_{k_n})=(\alpha_1,\alpha_2,\ldots,\alpha_n)C,\]
     其中
     \[C=\begin{pmatrix}
             1         & 1         & \cdots & 1         \\
             k_1       & k_2       & \cdots & k_n       \\
             \vdots    & \vdots    & \ddots & \vdots    \\
             k_1^{n-1} & k_2^{n-1} & \cdots & k_n^{n-1}
-        \end{pmatrix}\]
+        \end{pmatrix},\]
     则$|C|$是一个范德蒙行列式. 由范德蒙行列式的性质可知$|C| \neq 0$，因此$C$可逆. 又由于$\alpha_1,\alpha_2,\ldots,\alpha_n$是$V$的一组基，因此$\beta_{k_1},\beta_{k_2},\ldots,\beta_{k_n}$线性无关，从而向量组$\{\beta_k\}$中任意$n$个向量均构成$V$的一组基.
 
     由于$V_1,V_2,\ldots,V_s$是$V$的非平凡子空间，因此每个子空间最多包含$\{\beta_k\}$中$n-1$个向量，进而$V_1\cup V_2\cup\cdots\cup V_s$只包含$\{\beta_k\}$中有限个向量，所以必然存在一个向量$\beta_j$使得$\beta_j \notin V_1\cup V_2\cup\cdots\cup V_s$.
 \end{proof}
 
-除此之外教材上还有一些基于递推的方法的例子，我们将会在下一讲中展开介绍这一方法以及其它技巧性更强的方法.
-
 \section{行列式计算技巧}
 
-一个核心：观察行列式的特征，通过用一行消去其它所有行或者通过逐行相减化出更多的 $0$，得到模板行列式（例如上三角、箭形等）求解；或者其它的一些明显的技巧性方法例如递推法.
+行列式计算的核心思想：观察行列式的特征，通过用一行消去其它所有行或者通过逐行相减化出更多的 $0$，得到模板行列式（例如上三角、箭形等）求解；或者通过一些明显的技巧性方法（例如递推法）来求解.
 
 \subsection{化三角形法}
 
@@ -671,7 +846,7 @@
               &     & \ddots &     \\
               &     &        & -m
         \end{vmatrix}                                              \\
-            & =(-m)^{n-1}\left(\sum_{i=1}^{n} x_i-m\right)
+            & =(-m)^{n-1}\left(\sum_{i=1}^{n} x_i-m\right).
     \end{align*}
 \end{solution}
 
@@ -724,7 +899,7 @@
             1      & 1      & 1      & \cdots & 0      & 0      \\
             1      & 1      & 1      & \cdots & 1      & 0
         \end{vmatrix}                      \\
-            & =(-1)^{n+1}(n+1) 2^{n-2}
+            & =(-1)^{n+1}(n+1) 2^{n-2}.
     \end{align*}
 \end{solution}
 
@@ -739,7 +914,7 @@
                   &       & \ddots & -1      &         \\
                   &       &        & x       & -1      \\
             a_{0} & a_{1} & \cdots & a_{n-2} & a_{n-1}
-        \end{vmatrix}$
+        \end{vmatrix}$.
 \end{example}
 
 \begin{solution}
@@ -747,7 +922,7 @@
     \begin{align*}
         D_n & =\sum_{i=0}^{n-1}(-1)^{n+i+1}a_i\begin{vmatrix} A & O \\ O & B \end{vmatrix}
         =\sum_{i=0}^{n-1}(-1)^{n+i+1}a_i|A||B|                                                        \\
-            & =\sum_{i=0}^{n-1}(-1)^{n+i+1}a_i(x^i)\left((-1)^{n-1-i}\right) =\sum_{i=0}^{n-1}a_i x^i
+            & =\sum_{i=0}^{n-1}(-1)^{n+i+1}a_i(x^i)\left((-1)^{n-1-i}\right) =\sum_{i=0}^{n-1}a_i x^i,
     \end{align*}
 
     其中$A\in \mathbf{M}_i(\mathbf{R}),\enspace B\in \mathbf{M}_{n-1-i}(\mathbf{R})$，
@@ -764,7 +939,7 @@
                & x  & \ddots &    &    \\
                &    & \ddots & -1 &    \\
                &    &        & x  & -1
-        \end{pmatrix} \]
+        \end{pmatrix}. \]
 \end{solution}
 
 \begin{example}{}{}
@@ -774,7 +949,7 @@
             b       & \beta  & \gamma & \beta  & \cdots & \beta  \\
             \vdots  & \vdots & \vdots & \vdots & \ddots & \vdots \\
             b       & \beta  & \beta  & \beta  & \cdots & \gamma
-        \end{vmatrix}$
+        \end{vmatrix}$.
 \end{example}
 
 \begin{solution}
@@ -807,18 +982,18 @@
                                        \vdots       & \vdots       & \ddots & \vdots       \\
                                        0            & 0            & \cdots & \gamma-\beta
                                    \end{vmatrix}           \\
-            & =(\lambda \gamma+\lambda(n-2)\beta-(n-1)ab)(\gamma-\beta)^{n-2}
+            & =(\lambda \gamma+\lambda(n-2)\beta-(n-1)ab)(\gamma-\beta)^{n-2}.
     \end{align*}
 \end{solution}
 
-\begin{example}{}{}
-    计算行列式$D_n=\begin{vmatrix}
-            (a_1 + b_1)^{-1} & (a_1 + b_2)^{-1} & \cdots & (a_1 + b_n)^{-1} \\
-            (a_2 + b_1)^{-1} & (a_2 + b_2)^{-1} & \cdots & (a_2 + b_n)^{-1} \\
-            \vdots           & \vdots           & \ddots & \vdots           \\
-            (a_n + b_1)^{-1} & (a_n + b_2)^{-1} & \cdots & (a_n + b_n)^{-1}
-        \end{vmatrix}$.
-\end{example}
+% \begin{example}{}{}
+%     计算行列式$D_n=\begin{vmatrix}
+%             (a_1 + b_1)^{-1} & (a_1 + b_2)^{-1} & \cdots & (a_1 + b_n)^{-1} \\
+%             (a_2 + b_1)^{-1} & (a_2 + b_2)^{-1} & \cdots & (a_2 + b_n)^{-1} \\
+%             \vdots           & \vdots           & \ddots & \vdots           \\
+%             (a_n + b_1)^{-1} & (a_n + b_2)^{-1} & \cdots & (a_n + b_n)^{-1}
+%         \end{vmatrix}$.
+% \end{example}
 
 \subsection{升阶法}
 
@@ -844,7 +1019,7 @@
             \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
             0      & 1      & 1      & \cdots & 0      & 1      \\
             0      & 1      & 1      & \cdots & 1      & 0
-        \end{vmatrix} \]
+        \end{vmatrix}. \]
 
     再将第一行的 $-1$ 倍加到其他各行, 得:
     \[ D =\begin{vmatrix}
@@ -852,7 +1027,7 @@
             -1     & -1 &        &    \\
             \vdots &    & \ddots &    \\
             -1     &    &        & -1
-        \end{vmatrix} \]
+        \end{vmatrix}. \]
 
     从第二列开始, 每列乘以 $-1$ 加到第一列, 得:
     \begin{align*}
@@ -862,7 +1037,7 @@
                         &    & \ddots &    \\
                         &    &        & -1
              \end{vmatrix} \\
-          & =(-1)^{n+1}(n-1)
+          & =(-1)^{n+1}(n-1).
     \end{align*}
 \end{solution}
 
@@ -880,11 +1055,11 @@
 
 \begin{solution}
     \begin{align*}
-        D_1 & =\cos\beta                               \\
+        D_1 & =\cos\beta,                               \\
         D_2 & =\begin{vmatrix}
                    \cos\beta & 1          \\
                    1         & 2\cos\beta
-               \end{vmatrix}=2\cos^2\beta-1=\cos2\beta
+               \end{vmatrix}=2\cos^2\beta-1=\cos2\beta.
     \end{align*}
 
     猜想$D_n=\cos n\beta$. 数学归纳证明：
@@ -896,7 +1071,7 @@
                        & 1            & \ddots & 1            &              \\
                        &              & \ddots & 2 \cos \beta & 1            \\
                        &              &        & 1            & 2 \cos \beta
-        \end{vmatrix} \]
+        \end{vmatrix}. \]
 
     将 $D_{k+1}$ 按最后一行展开, 得
     \begin{align*}
@@ -916,7 +1091,7 @@
             \vdots     & \vdots       & \vdots       & \ddots & \vdots \\
             0          & 0            & 0            & \cdots & 1
         \end{vmatrix}       \\
-        ={}        & 2\cos\beta D_k-D_{k-1}
+        ={}        & 2\cos\beta D_k-D_{k-1}.
     \end{align*}
 
     而$D_{k}=\cos k \beta,\enspace
@@ -925,26 +1100,26 @@
         D_{k+1} & = 2 \cos \beta D_{k}-D_{k-1}                                               \\
                 & =2 \cos \beta \cos k \beta-\cos k \beta \cos \beta-\sin k \beta \sin \beta \\
                 & =\cos k \beta \cos \beta-\sin k \beta \sin \beta                           \\
-                & =\cos (k+1) \beta
+                & =\cos (k+1) \beta.
     \end{align*}
 
     则证得$D_n=\cos n\beta,\enspace n\in \mathbf{N}$.
 \end{solution}
 
 下面介绍常系数线性递推数列，为了方便，只介绍二阶情况. 如果$D_n$满足关系式
-\[ aD_n+bD_{n-1}+cD_{n-2}=0 \]
+\[ aD_n+bD_{n-1}+cD_{n-2}=0, \]
 解特征方程
 \[ ar^2+br+c=0 \]
 会有三种根的情况.
 \begin{enumerate}
     \item $\Delta>0$, 有两个不等的实根$r_1, r_2$，则有
-          \[ D_n=C_1r_1^n+C_2r_2^n \]
+          \[ D_n=C_1r_1^n+C_2r_2^n. \]
 
     \item $\Delta=0$, 有重实根$r$，则有
-          \[ D_n=(C_1+nC_2)r^n \]
+          \[ D_n=(C_1+nC_2)r^n. \]
 
     \item $\Delta<0$, 有共轭复根$r=\cos\beta\pm \i\sin\beta$，则有
-          \[ D_n=C_1\cos n\beta + C_2\sin n\beta \]
+          \[ D_n=C_1\cos n\beta + C_2\sin n\beta. \]
 \end{enumerate}
 以上式子中的$C_1,C_2$均为任意常数，可以令$n=1,2$获得.
 
@@ -963,20 +1138,20 @@
 
 \begin{solution}
     按第一列展开, 得
-    \[ D_n=9 D_{n-1}-20 D_{n-2} \]
+    \[ D_n=9 D_{n-1}-20 D_{n-2}, \]
     即 $ D_n-9 D_{n-1}+20 D_{n-2}=0 $.
 
     作特征方程
-    \[ x^{2}-9 x+20=0 \]
+    \[ x^{2}-9 x+20=0, \]
     解得 $ x_1=4,\enspace x_2=5 $. 则
-    \[ D_n=A \cdot 4^n+B \cdot 5^n \]
+    \[ D_n=A \cdot 4^n+B \cdot 5^n, \]
 
     当 $n=1$ 时, $9=4A+5B$；
 
     当 $n=2$ 时，$61=16A+25B$.
 
     解得$A=-4,\enspace B=5$，所以
-    \[ D_n=5^{n+1}-4^{n+1} \]
+    \[ D_n=5^{n+1}-4^{n+1}. \]
 \end{solution}
 
 最后我们介绍一个经典且复杂的例子，即所谓柯西行列式，我们利用递推法来求解：
@@ -1005,7 +1180,7 @@
                     \vdots                                      & \ddots & \vdots                                              & \vdots                 \\[2ex]
                     \dfrac{b_n-b_1}{(a_{n-1}+b_1)(a_{n-1}+b_n)} & \cdots & \dfrac{b_n-b_{n-1}}{(a_{n-1}+b_{n-1})(a_{n-1}+b_n)} & \dfrac{1}{a_{n-1}+b_n} \\[2ex]
                     \dfrac{b_n-b_1}{(a_n+b_1)(a_n+b_n)}         & \cdots & \dfrac{b_n-b_{n-1}}{(a_n+b_{n-1})(a_n+b_n)}         & \dfrac{1}{a_n+b_n}
-                \end{vmatrix}
+                \end{vmatrix}.
     \end{align*}
     第二步是提取公因式：
     \[ \text{上式} = \dfrac{\prod\limits_{i=1}^{n-1}(b_n-b_i)}{\prod\limits_{j=1}^{n}(a_j+b_n)}
@@ -1014,7 +1189,7 @@
             \vdots                 & \ddots & \vdots                     & \vdots \\[2ex]
             \dfrac{1}{a_{n-1}+b_1} & \cdots & \dfrac{1}{a_{n-1}+b_{n-1}} & 1      \\[2ex]
             \dfrac{1}{a_n+b_1}     & \cdots & \dfrac{1}{a_n+b_{n-1}}     & 1
-        \end{vmatrix} \]
+        \end{vmatrix}. \]
     第三步是将行列式的前 $n-1$ 行每行都减去第 $n$ 行：
     \[ \text{上式} = \dfrac{\prod\limits_{i=1}^{n-1}(b_n-b_i)}{\prod\limits_{j=1}^{n}(a_j+b_n)}
         \begin{vmatrix}
@@ -1022,7 +1197,7 @@
             \vdots                                      & \ddots & \vdots                                              & \vdots \\[2ex]
             \dfrac{a_n-a_{n-1}}{(a_{n-1}+b_1)(a_n+b_1)} & \cdots & \dfrac{a_n-a_{n-1}}{(a_{n-1}+b_{n-1})(a_n+b_{n-1})} & 0      \\[2ex]
             \dfrac{1}{a_n+b_1}                          & \cdots & \dfrac{1}{a_n+b_{n-1}}                              & 1
-        \end{vmatrix} \]
+        \end{vmatrix}. \]
     然后再次提取公因式：
     \begin{align*}
         \text{上式} & = \dfrac{\prod\limits_{i=1}^{n-1}(a_n-a_i)(b_n-b_i)}{\prod\limits_{j=1}^{n}(a_j+b_n)\prod\limits_{k=1}^{n-1}(a_n+b_k)}
@@ -1031,11 +1206,11 @@
             \vdots                 & \ddots & \vdots                     \\[2ex]
             \dfrac{1}{a_{n-1}+b_1} & \cdots & \dfrac{1}{a_{n-1}+b_{n-1}}
         \end{vmatrix}                                                         \\[2ex]
-                    & = \dfrac{\prod\limits_{i=1}^{n-1}(a_n-a_i)(b_n-b_i)}{\prod\limits_{j=1}^{n}(a_j+b_n)\prod\limits_{k=1}^{n-1}(a_n+b_k)} D_{n-1}
+                    & = \dfrac{\prod\limits_{i=1}^{n-1}(a_n-a_i)(b_n-b_i)}{\prod\limits_{j=1}^{n}(a_j+b_n)\prod\limits_{k=1}^{n-1}(a_n+b_k)} D_{n-1}.
     \end{align*}
     不断递推下去即得
 
-    \[|A| = \dfrac{\prod\limits_{1 \leqslant i < j \leqslant n}(a_j - a_i)(b_j - b_i)}{\prod\limits_{i,j=1}^{n}(a_i + b_j)}\]
+    \[|A| = \dfrac{\prod\limits_{1 \leqslant i < j \leqslant n}(a_j - a_i)(b_j - b_i)}{\prod\limits_{i,j=1}^{n}(a_i + b_j)}.\]
 \end{solution}
 
 \subsection{硬拆法}
@@ -1074,7 +1249,7 @@
                                           & -1      & \ddots & a_{n-1}   &         \\
                                           &         & \ddots & 1-a_{n-1} & a_{n}   \\
                                           &         &        & -1        & 1-a_{n}
-                               \end{vmatrix}
+                               \end{vmatrix}.
     \end{align*}
 
     上面第一个行列式的值为 1（从第 1 行开始，每一行依次加到下一行），所以
@@ -1095,7 +1270,7 @@
             & =1-a_{1}(1-a_{2} D_{n-2})                                 \\
             & =\cdots                                                   \\
             & =1-a_{1}+a_{1} a_{2}+\cdots+(-1)^n a_{1} a_{2} \cdots a_n \\
-            & =1+\sum_{i=1}^{n}(-1)^i \prod_{j=1}^i a_j
+            & =1+\sum_{i=1}^{n}(-1)^i \prod_{j=1}^i a_j.
     \end{align*}
 \end{solution}
 
@@ -1122,19 +1297,19 @@
             x_1^{n-2} & x_2^{n-2} & \cdots & x_n^{n-2} & x^{n-2} \\
             x_1^{n-1} & x_2^{n-1} & \cdots & x_n^{n-1} & x^{n-1} \\
             x_1^{n}   & x_2^{n}   & \cdots & x_n^{n}   & x^{n}
-        \end{vmatrix} \]
+        \end{vmatrix}. \]
 
     将 $f(x)$ 按第 $n+1$ 列展开, 得
-    \[ f(x)=A_{1, n+1}+A_{2, n+1} x+\cdots+A_{n, n+1} x^{n-1}+A_{n+1, n+1} x^{n} \]
+    \[ f(x)=A_{1, n+1}+A_{2, n+1} x+\cdots+A_{n, n+1} x^{n-1}+A_{n+1, n+1} x^{n}, \]
     其中 $x^{n-1}$ 的系数为
-    \[ A_{n, n+1}=(-1)^{n+(n+1)} D_n=-D_n \]
+    \[ A_{n, n+1}=(-1)^{n+(n+1)} D_n=-D_n. \]
 
     又根据 Vandermonde 行列式的结果知
-    \[ f(x)=(x-x_1)(x-x_2)\cdots(x-x_n) \prod_{1 \leqslant j<i \leqslant n}(x_i-x_j) \]
+    \[ f(x)=(x-x_1)(x-x_2)\cdots(x-x_n) \prod_{1 \leqslant j<i \leqslant n}(x_i-x_j). \]
     由上式可求得 $x^{n-1}$ 的系数为
-    \[ -(x_1+x_2+\cdots+x_n) \prod_{1 \leqslant j<i \leqslant n}(x_i-x_j) \]
+    \[ -(x_1+x_2+\cdots+x_n) \prod_{1 \leqslant j<i \leqslant n}(x_i-x_j). \]
     故有
-    \[ D_n=(x_1+x_2+\cdots+x_n) \prod_{1 \leqslant j<i \leqslant n}(x_i-x_j) \]
+    \[ D_n=(x_1+x_2+\cdots+x_n) \prod_{1 \leqslant j<i \leqslant n}(x_i-x_j). \]
 \end{solution}
 
 \subsection{利用$|E_m-AB|=|E_n-BA|$} \label{sec:利用|E_m-AB|=|E_n-BA|}
@@ -1156,7 +1331,7 @@
             1      & 2      & 2      & \cdots & n      \\
             \vdots & \vdots & \vdots & \ddots & \vdots \\
             1      & 2      & 3      & \cdots & n-1    \\
-        \end{vmatrix} \]
+        \end{vmatrix}. \]
 
     注意到这个行列式对应的矩阵可以加上一个单位矩阵构成一个每行都相等的矩阵，所以我们可以利用$|E_m-AB|=|E_n-BA|$来求解这个行列式.
     \begin{align*}
@@ -1177,7 +1352,7 @@
          & =(-1)^n\begin{vmatrix}E_n-
                       \begin{pmatrix}
                 1 \\1\\1\\\vdots\\1
-            \end{pmatrix}\begin{pmatrix}1 & 2 & 3 & \cdots & n\end{pmatrix}\end{vmatrix}
+            \end{pmatrix}\begin{pmatrix}1 & 2 & 3 & \cdots & n\end{pmatrix}\end{vmatrix}.
     \end{align*}
 
     而 \[ \begin{vmatrix}E_n-\begin{pmatrix}
@@ -1185,7 +1360,7 @@
             \end{pmatrix}\begin{pmatrix}1 & 2 & 3 & \cdots & n\end{pmatrix}\end{vmatrix}
         =1-\begin{pmatrix}1 & 2 & 3 & \cdots & n\end{pmatrix}
         \begin{pmatrix}1 \\ 1 \\ 1 \\ \vdots \\ 1\end{pmatrix}
-        =-\frac{n^2+n-2}{2} \]
+        =-\frac{n^2+n-2}{2}. \]
 
     所以原式$\displaystyle =(-1)^{n+1}\frac{n^2+n-2}{2}\prod_{i=1}^na_i$.
 \end{solution}
@@ -1288,7 +1463,7 @@
             2  & 1  & 1 & 3 & -1 \\
             1  & 2  & 2 & 1 & 0  \\
             0  & 3  & 0 & 1 & 3
-        \end{vmatrix}.$
+        \end{vmatrix}$.
 \end{example}
 
 \begin{solution}
@@ -1390,14 +1565,59 @@
 \end{example}
 
 \begin{solution}
-    见教材182页例1.
+    我们使用行列式来判断矩阵是否可逆：设 $A=\begin{pmatrix}
+            1 & 2 & 3 \\ 2 & 1 & 2 \\ 1 & 3 & 3
+        \end{pmatrix}$，则有 $|A| = 4$，因此 $A$ 可逆.
+
+    接着我们使用伴随矩阵求 $A$ 的逆矩阵. 首先求 $|A|$ 中各元素的代数余子式：
+
+    \[
+        A_{11} = \begin{vmatrix}
+            1 & 2 \\ 3 & 3
+        \end{vmatrix} = -3, \quad
+        A_{12} = - \begin{vmatrix}
+            2 & 2 \\ 1 & 3
+        \end{vmatrix} = -4, \quad
+        A_{13} = \begin{vmatrix}
+            2 & 1 \\ 1 & 3
+        \end{vmatrix} = 5.
+    \]
+
+    类似地，我们有
+    \begin{align*}
+        A_{21} &= 3, \quad A_{22} = 0, \quad A_{23} = -1, \\
+        A_{31} &= 1, \quad A_{32} = 4, \quad A_{33} = -3,
+    \end{align*}
+
+    由此可得 $A$ 的伴随矩阵 $A^* = \begin{pmatrix}
+            A_{11} & A_{21} & A_{31} \\
+            A_{12} & A_{22} & A_{32} \\
+            A_{13} & A_{23} & A_{33}
+        \end{pmatrix} = \begin{pmatrix}
+            -3 & 3 & 1 \\
+            -4 & 0 & 4 \\
+            5 & -1 & -3
+        \end{pmatrix}$
+
+    因此，
+
+    \[
+        A^{-1} = \dfrac{A^*}{|A|} = \dfrac{1}{4} \begin{pmatrix}
+            -3 & 3 & 1 \\
+            -4 & 0 & 4 \\
+            5 & -1 & -3
+            \end{pmatrix}
+    \]
+
 \end{solution}
 
+需要注意的是，在矩阵阶数较大时，使用伴随矩阵求逆矩阵需要求解大量的代数余子式，因此我们在实际计算中一般还是采用行变换（列变换）的方法求解逆矩阵.
+
 下面的例子也十分经典，是已知伴随矩阵求原矩阵，需要熟练运用伴随矩阵的性质：
-\begin{example}
-    已知$A^*=\begin{pmatrix}
+\begin{example}{}{}
+    已知 $A^*=\begin{pmatrix}
             1 & -2 & 1 \\ 0 & 2 & -2 \\ -1 & 2 & 1
-        \end{pmatrix}$，求$A$.
+        \end{pmatrix}$，求 $A$.
 \end{example}
 
 \begin{solution}
@@ -1461,9 +1681,11 @@
         \end{vmatrix}$.
 
     \begin{enumerate}
-        \item 方程组 \ref{eq:13:线性方程组1} 只有零解$\iff D \neq 0$，有非零解（无穷多解）$\iff D=0$，即$r(A)<n$；
+        \item 方程组 \ref{eq:13:线性方程组1} 只有零解$\iff D \neq 0$，\\
+              方程组 \ref{eq:13:线性方程组1} 有非零解（无穷多解）$\iff D=0$，即$r(A)<n$；
 
-        \item 方程组 \ref{eq:13:线性方程组2} 有唯一解$\iff D \neq 0$，此时$x_i=\dfrac{D_i}{D}\enspace(i=1,2,\ldots,n)$，当$D=0$时，方程组 \ref{eq:13:线性方程组2} 要么无解，要么有无穷多解.
+        \item 方程组 \ref{eq:13:线性方程组2} 有唯一解$\iff D \neq 0$，此时$x_i=\dfrac{D_i}{D}\enspace(i=1,2,\ldots,n)$，\\
+              当$D=0$时，方程组 \ref{eq:13:线性方程组2} 要么无解，要么有无穷多解.
     \end{enumerate}
 \end{theorem}
 
@@ -1608,7 +1830,19 @@
 \begin{theorem}{}{行列式秩等于行列式秩}
     矩阵$A$的秩$r(A)=r \iff A$的行列式的秩为$r$.
 \end{theorem}
-我们可以得到上一个专题中矩阵的秩的等价定义. 这一定理的证明见教材183页，事实上是很简单的. 我们可以这么理解，最高非零子式的阶数实际上就是矩阵行、列向量极大线性无关组的长度（更多行、列向量就会使得子式等于0，此时必不满秩），那么这一定理就很显然了.
+\begin{proof}
+    \begin{enumerate}
+        \item 先证 $r(A)=r \implies A$ 的行列式秩为 $r$：
+
+            由 $r(A) = r$ 可得 $A$ 的行秩为 $r$，不妨设 $A$ 的前 $r$ 行构成的矩阵 $A_1$ 的行秩为 $r$，其列秩也为 $r$；不妨再设 $A_1$ 的前 $r$ 列向量线性无关. 如此，$A$ 的左上角的 $r$ 阶子块是可逆矩阵，其行列式是 $A$ 的一个 $r$ 阶非零子式；又因为 $A$ 的任意 $r+1$ 个行向量线性相关，因此任意 $r+1$ 阶子式都是零子式. 故 $A$ 的行列式秩为 $r$.
+
+        \item 再证 $A$ 的行列式秩为 $r \implies r(A)=r$：
+
+            不妨设 $A$ 的左上角 $r$ 阶子式 $|A_0|$ 为非零子式. 于是 $A_0$ 可逆，其 $r$ 个行向量线性无关，将它们添分量构成 $A$ 的前 $r$ 个行向量，它们也线性无关；而且此时 $A$ 中任意 $r+1$ 行线性相关（否则 $A$ 中存在 $r+1$ 阶非零子式），故矩阵 $A$ 的行秩为 $r$，即 $r(A)=r$.
+    \end{enumerate}
+\end{proof}
+
+该定理给出了一个上个专题中矩阵的秩的等价定义. 我们可以这么理解，最高非零子式的阶数实际上就是矩阵行、列向量极大线性无关组的长度（更多行、列向量就会使得子式等于0，此时必不满秩），那么这一定理就很显然了.
 
 \begin{definition}{}{}
     矩阵$A$的非零子式的最高阶数$r$称为矩阵$A$的秩，记为$r(A)$.
@@ -1637,7 +1871,7 @@
 
     \item 在\autoref{thm:行列式秩等于行列式秩} 中统一了矩阵的秩和行列式的秩.
 \end{enumerate}
-虽然线性映射的秩、矩阵的秩、行列式的秩的定义各不相同，但本质都在于向量组的秩（回顾线性映射的秩的定义，矩阵行秩、列秩的定义，乃至\autoref*{thm:行列式秩等于行列式秩} 的证明）. 这给我们的启示是上述提到的概念都可以互相转化考虑. 例如考虑可逆时，我们可以考虑行、列向量是否线性无关/矩阵对应的线性映射是否可逆/行列式是否为0等. 虽然说起来很简单，但是实际做题的时候很多同学还是容易思维局限，因此我们需要将这些概念的统一性放在重要的位置.
+虽然线性映射的秩、矩阵的秩、行列式的秩的定义各不相同，但本质都在于向量组的秩（回顾线性映射的秩的定义，矩阵行秩、列秩的定义，乃至\autoref{thm:行列式秩等于行列式秩} 的证明）. 这给我们的启示是上述提到的概念都可以互相转化考虑. 例如考虑可逆时，我们可以考虑行、列向量是否线性无关/矩阵对应的线性映射是否可逆/行列式是否为0等. 虽然说起来很简单，但是实际做题的时候很多同学还是容易思维局限，因此我们需要将这些概念的统一性放在重要的位置.
 \begin{example}{}{}
     求多项式$f(x)=\begin{vmatrix}
             1 & a_1   & a_2     & a_3     \\

--- a/讲义/专题/3 有限维线性空间.tex
+++ b/讲义/专题/3 有限维线性空间.tex
@@ -651,16 +651,125 @@
             \item  若 $W_1, W_2$ 是 $ \mathbf{R}^n $ 的两个子空间，$B_1, B_2$ 分别是 $W_1, W_2$ 的基，则存在 $ \mathbf{R}^n $ 的一组基 $B$，使得 $B \supseteq B_1 \cup B_2$。
 
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 错. 反例：$\alpha_1=(1,0),\alpha_2=(2,0),\alpha_3=(0,1)$，则 $\alpha_1,\alpha_2,\alpha_3$ 线性相关而 $\alpha_3$ 不是 $\alpha_1.\alpha_2$ 的线性组合.
+
+                \item 对. 该命题的等价命题（逆否命题）是：若存在一个向量是其余向量的线性组合，则 $\alpha_1,\ldots,\alpha_m$ 线性相关. 这正是定理 3.1 的内容，因而成立.
+
+                \item 错. 反例：$\alpha_1=(1,0),\alpha_2=(0,1),\alpha_3=(1,1)$，则 $\alpha_1,\alpha_2,\alpha_3$ 两两无关，而三者线性相关. 可证两两无关是向量组无关的必要条件.
+
+                \item 错. 反例：$\alpha_1=(1,0),\alpha_2=(0,0),\beta_1=(0,0),\beta_2=(0,1)$，有 $\alpha_1,\alpha_2$ 相关，$\beta_1,\beta_2$ 相关，而 $\alpha_1+\beta_1$ 与 $\alpha_2+\beta_2$ 线性无关.
+
+                \item 错. 若 $\alpha_1,\ldots,\alpha_n$ 线性无关，有
+                    \[\lambda_1\alpha_1+\cdots+\lambda_n\alpha_n\implies\lambda_1=\lambda_2=\cdots=\lambda_n=0,\]
+                    判断 $\alpha_1+\alpha_2,\alpha_2+\alpha_3,\ldots,\alpha_n+\alpha_1$ 是否无关. 设
+                    \[\lambda_1'(\alpha_1+\alpha_2)+\cdots+\lambda_n'(\alpha_n+\alpha_1)=0,\]
+                    则
+                    \[(\lambda_n'+\lambda_1')\alpha_1+(\lambda_1'+\lambda_2')\alpha_2+\cdots+(\lambda_{n-1}'+\lambda_{n}')\alpha_n=0,\]
+                    则
+                    \[\begin{cases} \begin{aligned}
+                                \lambda_n'+\lambda_1'       & = 0               \\
+                                                            & \vdotswithin{ = } \\
+                                \lambda_{n-1}'+\lambda_{n}' & = 0               \\
+                            \end{aligned} \end{cases}.\]
+                    解该方程可得 $\lambda_n'=(-1)^n\lambda_1'$，因此当 $n$ 为偶数时，上述方程组有非零解，则向量组相关，而当 $n$ 为奇数时，向量组无关. 综上，该命题不成立.
+
+                \item 对. 由定理 3.1，不妨设 $\alpha_3$ 可由 $\alpha_1,\alpha_2$ 线性表示，则 $\alpha_1+\alpha_2,\alpha_2+\alpha_3,\alpha_3+\alpha_1$ 均可由 $\alpha_1,\alpha_2$ 线性表示，再由定理 3.3 可知，$\alpha_1+\alpha_2,\alpha_2+\alpha_3,\alpha_3+\alpha_1$ 线性相关.
+
+                \item 错. 反例：取 $\alpha_0=\alpha_1-\alpha_2-\alpha_3$，则 $\alpha_0+\alpha_1=(\alpha_0+\alpha_2)+(\alpha_0+\alpha_3)$，三者线性相关，不是 $\mathbf{R}^3$ 的基.
+
+                \item 对. 判断 $\alpha_1+\alpha_2$ 与 $\alpha_1-\alpha_2$ 是否无关.
+                    \[\lambda_1(\alpha_1+\alpha_2)+\lambda_2(\alpha_1-\alpha_2)=0,\]
+                    则有$(\lambda_1+\lambda_2)\alpha_1+(\lambda_1-\lambda_2)\alpha_2=0$，则 $\lambda_1+\lambda_2=0,\lambda_1-\lambda_2=0\implies \lambda_1=\lambda_2=0$，因此线性无关且个数等于维数，是一组基.
+
+                \item 错. 反例：$\mathbf{R}^2$ 中过原点的直线 $L_0$ 是 $\mathbf{R}^2$ 的一个子空间. 显然这样的直线有无数条.
+
+                \item 错. 反例：$\mathbf{R}^3$ 中，子空间 $W_1=\spa(e_1,e_2)$，$W_2=\spa(e_1+e_2,e_3)$，则 $B_1\cup B_2=\{e_1,e_2,e_3,e_1+e_2\}$，显然 $\mathbf{R}^3$ 中的任一组基都不可能包含四个元素.
+            \end{enumerate}
+        \end{answer}
 
         \item 证明：如果向量组线性相关，把每个向量去掉$m$个位置一致的分量，得到的缩短组仍线性相关；如果向量组线性无关，把每个向量添加$m$个位置一致的分量，得到的缩短组仍线性无关；
+        \begin{answer}
+            \begin{enumerate}
+                \item 若向量组线性相关，则对应该方程组有无穷多解. 去掉 $m$ 个分量，相当于删去该方程组中的任意 $m$ 行方程，依然有无穷多解. 这是因为对于原方程组的任意一个解，将其带入被削减后的方程组也依然成立. 故线性相关得证.
+
+                \item 若向量组线性无关，对应原方程组仅有唯一解，也就是全零解. 增加 $m$ 个分量相当于增加 $m$ 个方程，依然只有唯一解，因为若出现非零解，代入原方程组对应的方程中不会成立，矛盾. 故线性无关得证.
+            \end{enumerate}
+        \end{answer}
 
         \item $a$取何值时，$\beta_1=(1,3,6,2)^\mathrm{T},\beta_2=(2,1,2,-1)^\mathrm{T},\beta_3=(1,-1,a,-2)^\mathrm{T}$线性无关？
+        \begin{answer}
+            方程组：$x_1\beta_1+x_2\beta_2+x_3\beta_3=0$ 系数矩阵
+            \[\begin{pmatrix}
+                    1 & 2  & 1  \\
+                    3 & 1  & -1 \\
+                    6 & 2  & a  \\
+                    2 & -1 &
+                    -2\end{pmatrix}\rightarrow\begin{pmatrix}
+                    1 & 2   & 1   \\
+                    0 & -5  & -4  \\
+                    0 & -10 & a-6 \\
+                    0 & -6  & -4
+                \end{pmatrix}\rightarrow\begin{pmatrix}
+                    1 & 2  & 1   \\
+                    0 & -5 & -4  \\
+                    0 & 0  & a+2 \\
+                    0 & 0  & 0
+                \end{pmatrix},\]
+            仅全零解的条件是 $a\neq-2$，此时向量组线性无关.
+        \end{answer}
 
         \item 设$\alpha_1,\alpha_2,\ldots,\alpha_n\in\mathbf{F}^n$. 证明：$\alpha_1,\alpha_2,\ldots,\alpha_n$线性无关的充要条件是$\mathbf{F}^n$中任一向量都可以由它们线性表示.
+        \begin{answer}
+            \begin{enumerate}
+                \item 必要性：$\alpha_1,\ldots,\alpha_n$ 线性无关，对于 $F^n$ 中的任一向量 $\beta$, $\alpha_1,\ldots,\alpha_n,\beta$ 的向量个数大于维数 $n$，则线性相关. 由定理 3.2，$\beta$ 可被 $\alpha_1,\ldots,\alpha_n$ 唯一表示.
+
+                \item 充分性：由于 $F^n$ 中任意向量均可被 $\alpha_1,\ldots,\alpha_n$ 线性表示，并且向量个数等于维数. 则 $\alpha_1,\ldots,\alpha_n$ 是 $F^n$ 的一组基. 则 $\alpha_1,\ldots,\alpha_n$ 线性无关.
+
+                      $^*$ 更详细的证明：对于 $F^n$ 的一组基 $e_1,\ldots,e_n$，其可被 $\alpha_1,\ldots,\alpha_n$ 表示. 若 $\alpha_1,\ldots,\alpha_n$ 线性相关，不妨设 $\alpha_n$ 可被 $\alpha_1,\ldots,\alpha_{n-1}$ 表示，则有 $e_1,\ldots,e_n$ 可被 $\alpha_1,\ldots,\alpha_{n-1}$ 表示. 由于 $e_1,\ldots,e_n$ 线性无关. 根据定理 3.3，$n\leqslant n-1$，矛盾. 因此得证.
+            \end{enumerate}
+        \end{answer}
 
         \item 设$S_1=\{\alpha_1,\ldots,\alpha_s\},S_2=\{\beta_1,\ldots,\beta_t\}$是向量空间$V$的两个线性无关的子集，证明：$\alpha_1,\ldots,\alpha_s,\beta_1,\ldots,\beta_t$线性无关$\iff \spa(S_1)\cap \spa(S_2)=\{0\}$.
+        \begin{answer}
+            \begin{enumerate}
+                \item 必要性：对于 $\forall v\in\spa(S_1) \cap \spa(S_2)$ 有 $v=a_1\alpha_1+\cdots+a_s\alpha_s=b_1\beta_1+\cdots+b_t\beta_t$. 由于 $\alpha_1,\ldots,\alpha_s,\beta_1,\ldots,\beta_t$ 线性无关 $\implies a_1=\cdots=a_s=b_1=\cdots=b_t=0$，则 $v=0$，即 $\spa(S_1)\cap\spa(S_2)=\{0\}$.
+
+                \item 充分性：考虑反证法. 如果 $\alpha_1,\ldots,\alpha_s,\beta_1,\ldots,\beta_t$ 线性相关，则存在不全为零的系数使得 $a_1\alpha_1+\cdots+a_s\alpha_s+b_1\beta_1\cdots+b_t\beta_t=0$. 因此存在一个向量 $v=a_1\alpha_1+\cdots+a_s\alpha_s=-(b_1\beta_1\cdots+b_t\beta_t)\neq 0$ 且 $v\in\spa(S_1),v\in\spa(S_2)$. 即存在非零向量 $v$ 属于 $\spa(S_1),v\in\spa(S_2)$，矛盾！则充分性得证.
+            \end{enumerate}
+        \end{answer}
 
         \item 完成 \autoref{lem:初等行变换不改变列的线性相关性} 其它两种初等行变换的证明.
+        \begin{answer}
+            设矩阵为
+            \[
+                \begin{pmatrix}
+                    a_{11} & a_{12} & \cdots & a_{1n} \\
+                    a_{21} & a_{22} & \cdots & a_{2n} \\
+                    \vdots & \vdots & \ddots & \vdots \\
+                    a_{m1} & a_{m2} & \cdots & a_{mn}
+                \end{pmatrix},
+            \]
+
+            \begin{enumerate}
+                \item 对其进行倍乘行变换，即将第 $i$ 行乘以 $c$，那么第 $i$ 行会变为 $c a_{i1}, c a_{i2}, \ldots, c a_{in}$，而其他行不变. 记原先矩阵的列向量为 $S_A = \{\alpha_1,\alpha_2,\ldots,\alpha_n\}$，变换后的矩阵列向量为 $S_B = \{\beta_1,\beta_2,\ldots,\beta_n\}$.
+
+                    先证 $S_A$ 线性相关 $\implies S_B$ 线性相关：若 $S_A$ 线性相关，则存在不全为零的系数 $x_1, x_2, \ldots, x_n$ 使得 $x_1 \alpha_1 + x_2 \alpha_2 + \cdots + x_n \alpha_n = 0$. 由于 $S_B$ 与 $S_A$ 只有第 $i$ 行不同，我们仅需要判断第 $i$ 行中的元素在系数 $x_1, x_2, \ldots, x_n$ 下的线性组合是否为 $0$ 即可. 事实上我们有 $x_1 c a_{i1} + x_2 c a_{i2} + \cdots + x_n c a_{in} = c(x_1 a_{i1} + x_2 a_{i2} + \cdots + x_n a_{in}) = 0$，故 $S_B$ 线性相关.
+
+                    再证 $S_B$ 线性相关 $\implies S_A$ 线性相关：若 $S_B$ 线性相关，由于倍乘行变换保证 $c \neq 0$，故从 $S_B$ 到 $S_A$ 相当于做一次将第 $i$ 行乘以 $\frac{1}{c}$ 的行变换，同理可得 $S_A$ 线性相关.
+
+                    因此，对矩阵做倍乘行变换不改变矩阵的列的线性相关性.
+
+                \item 对其进行对换行变换，即将第 $i$ 行与第 $j$ 行交换，其他行不变. 记原先矩阵的列向量为 $S_A = \{\alpha_1,\alpha_2,\ldots,\alpha_n\}$，变换后的矩阵列向量为 $S_B = \{\beta_1,\beta_2,\ldots,\beta_n\}$.
+
+                    先证 $S_A$ 线性相关 $\implies S_B$ 线性相关：若 $S_A$ 线性相关，则存在不全为零的系数 $x_1, x_2, \ldots, x_n$ 使得 $x_1 \alpha_1 + x_2 \alpha_2 + \cdots + x_n \alpha_n = 0$. 由于 $S_B$ 与 $S_A$ 只有第 $i$ 行与第 $j$ 行不同，我们仅需要判断第 $i$ 行与第 $j$ 行中的元素在系数 $x_1, x_2, \ldots, x_n$ 下的线性组合是否均为 $0$ 即可. 事实上由原先第 $i$（$j$）行的元素在 $x_1, x_2, \ldots, x_n$ 下的线性组合为 $0$ 即可得到变换后第 $j$（$i$）行的元素的线性组合为 $0$，故 $S_B$ 线性相关.
+
+                    再证 $S_B$ 线性相关 $\implies S_A$ 线性相关：若 $S_B$ 线性相关，从 $S_B$ 到 $S_A$ 相当于再做一次相同的对换行变换，同理有 $S_A$ 线性相关.
+
+                    因此，对矩阵做对换行变换不改变矩阵的列的线性相关性.
+            \end{enumerate}
+        \end{answer}
 
         \item 已知$\alpha_1=(1,2,4,3),\alpha_2=(1,-1,-6,6),\alpha_3=(-2,-1,2,-9),\alpha_4=(1,1,-2,7),\beta=(4,2,4,a)$.
         \begin{enumerate}
@@ -668,18 +777,93 @@
 
             \item 求$a$的值使得$\beta\in W$，并求$\beta$在 (1) 所选基下的坐标.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 也就是求 $\alpha_1,\alpha_2,\alpha_3,\alpha_4$ 的极大线性无关组. 利用讲义中所述求法：方程组
+                      \[ a_1\alpha_1+\cdots+a_4\alpha_4=0 \]
+                      对应系数矩阵 $\begin{pmatrix}
+                              1 & 1  & -2 & 1  \\
+                              2 & -1 & -1 & 1  \\
+                              4 & -6 & 2  & -2 \\
+                              3 & 6  & -9 & 7\end{pmatrix}$. 化简为行阶梯型：$\begin{pmatrix}
+                              1 & 1  & -2 & 1  \\
+                              0 & -3 & 3  & -1 \\
+                              0 & 0  & 0  & 3  \\
+                              0 & 0  & 0  & 0\end{pmatrix}$，因此 $\alpha_1,\alpha_2,\alpha_3,\alpha_4$ 有非零解，这四个向量线性相关. （其实此处已知矩阵秩为 3，即维数是 3）.
+
+                      再选取 $\alpha_1,\alpha_2,\alpha_4$ 来求解方程 $a_1\alpha_1+a_2\alpha_2+a_4\alpha_4=0$：
+                      \[\begin{pmatrix}
+                              1 & 1  & 1  \\
+                              2 & -1 & 1  \\
+                              4 & -6 & -2 \\
+                              3 & 6  & 7\end{pmatrix}\rightarrow\begin{pmatrix}
+                              1 & 1  & 1  \\
+                              0 & -3 & -2 \\
+                              0 & 0  & 2  \\
+                              0 & 0  & 0\end{pmatrix},\]
+                      因此该方程组只有全零解，即 $\alpha_1,\alpha_2,\alpha_4$ 是$\alpha_1,\alpha_2,\alpha_3,\alpha_4$的极大线性无关组. 则 $\spa(\alpha_1,\alpha_2,\alpha_4)$ 的维数是 3. 一组基是 $\alpha_1,\alpha_2,\alpha_4$ .
+
+                \item 也就是 $a_1\alpha_1+\cdots+a_4\alpha_4=\beta$有解：增广矩阵 $\begin{pmatrix}
+                              1 & 1  & -2 & 1  & 4 \\
+                              2 & -1 & -1 & 1  & 2 \\
+                              4 & -6 & 2  & -2 & 4 \\
+                              3 & 6  & -9 & 7  & a\end{pmatrix}$化为 $\begin{pmatrix}
+                              1 & 1  & -2 & 1         & 4   \\
+                              0 & -3 & 3  & -1        & -6  \\
+                              0 & 0  & 0  & -\frac 83 & 8   \\
+                              0 & 0  & 0  & 0         & a-9\end{pmatrix}$，若方程有解，则 $a=9$. 求坐标，取 $x_3=0$ 代入得 $\beta=4\alpha_1+3\alpha_2-3\alpha_4$.
+            \end{enumerate}
+        \end{answer}
 
         \item 证明：$B=\{1,x-a,(x-a)^2\}\enspace(a\neq 0)$是$\mathbf{R}[x]_3$的一组基，并求$\mathbf{R}[x]_3$的自然基$\{1,x,x^2\}$中每个向量关于基$B$的坐标.
+        \begin{answer}
+            只需证明 $B$ 线性无关即可. $\lambda_1+\lambda_2(x_a)+\lambda_3(x-a)^2$求导，增加方程数得到
+            \begin{gather*}
+                \lambda_2+2\lambda_3x=0, \\
+                2\lambda_3=0,
+            \end{gather*}
+            则 $\lambda_1=\lambda_2=\lambda_3$，线性无关得证. 又 $B$ 中向量个数等于 $R[x]_3$ 维数. 则 $B$ 是一组基. $1=1 \cdot 1+0 \cdot (x-a)+0\times(x-a)^2$ ，即 $(1,0,0)$；$x=a \cdot 1+1 \cdot (x-a)+0\times(x-a)^2$ ，即 $(a,1,0)$；$x^2=a^2 \cdot 1+2a \cdot (x-a)+1\times(x-a)^2$ ，即 $(a^2,2a,1)$.
+        \end{answer}
 
         \item 已知向量组$A=\{\alpha_1,\alpha_2,\alpha_3\},\enspace B=\{\alpha_1,\alpha_2,\alpha_3,\alpha_4\},\enspace C=\{\alpha_1,\alpha_2,\alpha_3,\alpha_5\}$的秩分别为$r(A)=r(B)=3,\enspace r(C)=4$. 证明：$\{\alpha_1,\alpha_2,\alpha_3,\alpha_5-\alpha_4\}$的秩为4.
+        \begin{answer}
+            等价于证明 $\alpha_1,\alpha_2,\alpha_3,\alpha_5-\alpha_4$ 线性无关. 即求解
+            \begin{equation}
+                \lambda_1\alpha_1+\lambda_2\alpha_2+\lambda_3\alpha_3+\lambda_4(\alpha_5-\alpha_4)=0. \tag{*} \label{eq:3:A.10}
+            \end{equation}
+
+            由于 $r(A)=r(B)=3$ 可得 $A$ 线性无关. $B$ 线性相关. 由定理 3.2 得 $\alpha_4$ 可由 $\alpha_1,\alpha_2,\alpha_3$ 唯一表示：$\alpha_4=\mu_1\alpha_1+\mu_2\alpha_2+\mu_3\alpha_3$. 则代入 (\ref*{eq:3:A.10}) 式. 有
+            \[(\lambda_1-\mu_1\lambda_4)\alpha_1+(\lambda_2-\mu_2\lambda_4)\alpha_2+(\lambda_3-\mu_3\lambda_4)\alpha_3+\lambda_4\alpha_5=0,\]
+            因为 $r(C)=4$，$\alpha_1,\alpha_2,\alpha_3,\alpha_5$ 线性无关. 有 $\lambda_4=0,\lambda_1=\mu_1\lambda_4=0,\lambda_2=\mu_2\lambda_4=0,\lambda_3=\mu_3\lambda_4=0$. 故 $\alpha_1,\alpha_2,\alpha_3,\alpha_5-\alpha_4$ 线性无关. 原题得证.
+        \end{answer}
 
         \item 设向量组$\alpha_1,\alpha_2,\ldots,\alpha_s$的秩为$r$. 在其中任取$m$个向量$\alpha_{i1},\alpha_{i2},\ldots,\alpha_{im}$，证明：向量组$\alpha_{i1},\alpha_{i2},\ldots,\alpha_{im}$的秩$\geqslant r+m-s$.
+        \begin{answer}
+            相当于从 $\alpha_1,\ldots,\alpha_s$ 向量中选取 $s-m$ 个向量丢弃，剩余向量的秩：
+            \[r(\alpha_{i1},\ldots,\alpha_{im})\geqslant r-(s-m) =r+m-s.\]
+        \end{answer}
 
         \item 已知$\alpha_1,\alpha_2,\ldots,\alpha_n$线性无关，而$\alpha_1,\alpha_2,\ldots,\alpha_n,\beta,\gamma$线性相关. 证明：要么$\beta,\gamma$可以由$\alpha_1,\alpha_2,\ldots,\alpha_n$线性表示，要么$\alpha_1,\alpha_2,\ldots,\alpha_n,\beta$与$\alpha_1,\alpha_2,\ldots,\alpha_n,\gamma$等价.
+        \begin{answer}
+            方程：$\lambda_1\alpha_1+\cdots+\lambda_n\alpha_n+\lambda_{n+1}\beta+\lambda_{n+2}\gamma=0$，显然 $\lambda_{n+1},\lambda_{n+2}$ 不全为零. 否则与 $\alpha_1,\ldots,\alpha_n$ 线性无关矛盾.
+            \begin{enumerate}
+                \item 若 $\lambda_{n+1}=0,\lambda_{n+2}\neq 0$，则 $\gamma$ 可被 $\alpha_1,\ldots,\alpha_n$ 表示. 若 $\lambda_{n+1}\neq0,\lambda_{n+2}=0$， 则 $\beta$ 可被 $\alpha_1,\ldots,\alpha_n$ 表示.
+
+                \item 若 $\lambda_{n+1}\lambda_{n+2}\neq 0$ ，则有
+                      \begin{gather*}
+                          \beta=-\frac 1{\lambda_{n+1}}(\lambda_1\alpha_1+\cdots+\lambda_n\alpha_n+\lambda_{n+2}\gamma), \\
+                          \gamma=-\frac 1{\lambda_{n+2}}(\lambda_1\alpha_1+\cdots+\lambda_n\alpha_n+\lambda_{n+1}\beta).
+                      \end{gather*}
+                    两组向量可以相互表示. 两者等价. 综上原题得证.
+            \end{enumerate}
+        \end{answer}
     \end{exgroup}
 
     \begin{exgroup}
         \item 已知$\alpha_1\neq 0$，则$\alpha_1,\alpha_2,\ldots,\alpha_n$线性相关的充要条件是存在$i\enspace(2 \leqslant i \leqslant n)$使得$\alpha_i$可由$\alpha_1,\alpha_2,\ldots,\alpha_{i-1}$线性表示，且表示法唯一.
+        \begin{answer}
+            充分性显然成立，下证必要性：由于 $\alpha_1,\ldots,\alpha_n$ 线性相关，则存在 $m$，其能使得 $\alpha_1,\ldots,\alpha_m$ 线性无关的最大下标，有 $1\leqslant m<n$. 因此 $i=m+1$，$\alpha_1,\ldots,\alpha_{i-1}$ 线性无关，$\alpha_1,\ldots,\alpha_i$ 线性相关. 可得 $\alpha_i$ 可被 $\alpha_1,\ldots,\alpha_{i-1}$ 唯一表示.
+        \end{answer}
 
         \item 证明以下两个结论：
         \begin{enumerate}
@@ -687,16 +871,53 @@
 
             \item 设$U$和$W$都是$V$的非零子空间，$U\subseteq W$，且$\dim U = \dim W$，则$U = W$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 设 $U$ 的一组基为 $u_1,\ldots,u_m$，$W$ 的一组基为 $w_1,\ldots,w_n$. 由于 $U\subseteq W$，则 $u_1,\ldots,u_m$ 可由 $w_1,\ldots,w_n$ 线性表示，且 $u_1,\ldots,u_m$ 线性无关. 由定理 3.3 的等价命题可得 $m\leqslant n$，则 $m=\dim U\leqslant\dim W=n$ 的得证.
+
+                \item 因为 $\dim U=\dim W$，则 $u_1,\ldots,u_m$ 也是 $W$ 的一组基. 则 $W$ 的任意向量均可由 $u_1,\ldots,u_m$ 表示，可得 $W\subseteq U$，而 $U\subseteq W$，故有 $U=W$ 得证.
+            \end{enumerate}
+        \end{answer}
 
         \item 设向量组$\alpha_1,\alpha_2,\ldots,\alpha_n$线性无关. 证明：在向量组$\beta,\alpha_1,\alpha_2,\ldots,\alpha_n$中至多有一个向量$\alpha_i\enspace(1 \leqslant i \leqslant r)$可被其前面的$i$个向量$\beta,\alpha_1,\alpha_2,\ldots,\alpha_{i-1}$线性表示.
+        \begin{answer}
+            反证法. 若存在两个向量 $\alpha_i,\alpha_j$ 可被前面的向量表示，即
+            \begin{gather*}
+                \alpha_i=\lambda_0\beta+\lambda_1\alpha_1+\cdots+\lambda_{i-1}\alpha_{i-1}, \\
+                \alpha_j=\mu_0\beta+\mu_1\alpha_1+\cdots+\mu_{j-1}\alpha_{j-1}.
+            \end{gather*}
+            如果 $\lambda_0$ 或者 $\mu_0$ 为 0，则有向量组中的 $\alpha_i$ 或 $\alpha_j$ 可被其他向量线性表示，则该向量组相关，这与条件矛盾. 若 $\lambda_0$ 与 $\mu_0$ 均不为 0，等式可化为
+            \begin{gather*}
+                \frac 1{\lambda_0}\alpha_i=\beta+\frac{\lambda_1}{\lambda_0}\alpha_1+\cdots+\frac{\lambda_{i-1}}{\lambda_0}\alpha_{i-1}, \\
+                \frac 1{\mu_0}\alpha_j=\beta+\frac{\mu_1}{\mu_0}\alpha_1+\cdots+\frac{\mu_{j-1}}{\mu_0}\alpha_{j-1}.
+            \end{gather*}
+            不妨设 $i>j$. 相减得
+            \[\frac 1{\lambda_0}\alpha_i=\left(\frac{\lambda_1}{\lambda_0}-\frac{\mu_1}{\mu_0}\right)\alpha_1+\cdots+\left(\frac{\lambda_i}{\lambda_0}+\frac 1{\mu_0}\right)\alpha_j+\frac{\lambda_{i-1}}{\lambda_0}\alpha_{i-1},\]
+            则 $\alpha_i$ 可被其他向量线性表示，因此向量组线性相关，与条件矛盾. 综上，至多有一个向量 $\alpha_i$ 可被前面的相邻线性表示.
+        \end{answer}
 
         \item 证明：$1,e^{\lambda_1\cdot x},e^{\lambda_2\cdot x}$（$\lambda_1\neq\lambda_2$且均不为0）线性无关.
+        \begin{answer}
+            考虑使用求导构造更多方程.
+            \[\begin{cases}
+                    k_0+k_1\cdot e^{\lambda_1 x}+k_2\cdot e^{\lambda_2 x}=0               \\
+                    k_1\lambda_1\cdot e^{\lambda_1 x}+k_2\lambda_2\cdot e^{\lambda_2 x}=0 \\
+                    k_1\lambda_1^2\cdot e^{\lambda_1 x}+k_2\lambda_2^2\cdot e^{\lambda_2 x}=0
+                \end{cases},\]
+          由后两式可知$k_1k_2(\lambda_1-\lambda_0)=0$. 又 $\lambda_1\neq\lambda_2$，故$k_1=k_2=0$，代回第一式得 $k_0=0$，则 $1,e^{\lambda_1x},e^{\lambda_2x}$ 线性无关，得证.
+        \end{answer}
 
         \item 设线性空间$V(\mathbf{F})$中，向量$\beta$是$\alpha_1,\ldots,\alpha_r$的线性组合，但不是$\alpha_1,\ldots,\alpha_{r-1}$的线性组合. 证明：$\spa(\alpha_1,\ldots,\alpha_{r-1},\alpha_r)=\spa(\alpha_1,\ldots,\alpha_{r-1},\beta)$.
+        \begin{answer}
+            只需证明 $\alpha_r$ 可以被 $\alpha_1,\ldots,\alpha_{r-1},\beta$ 表示即可. 由于 $\beta$ 是 $\alpha_1,\ldots,\alpha_{r-1}$ 的线性组合，若 $\lambda_r=0$，则 $\beta$ 是 $\alpha_1,\ldots,\alpha_{r-1}$ 的线性组合. 这与条件矛盾. 因此 $\alpha_r=-\vspace{1ex}\dfrac 1{\lambda_r}(\lambda_1\alpha_1+\cdots+\lambda_{r-1}\alpha_{r-1}-\beta)$，则这两组向量等价. $\spa(\alpha_1,\ldots,\alpha_{r-1},\alpha_r)=\spa(\alpha_1,\ldots,\alpha_{r-1},\beta)$ 得证.
+        \end{answer}
 
         \item 设$\mathbf{R}^+$是所有正实数组成的集合，加法和数乘定义如下：
         \[ \forall a,b \in \mathbf{R}_+,\enspace k\in \mathbf{R}\colon\enspace a\oplus b = ab,\enspace k\odot a = a^k \]
         则 $\mathbf{R}^+$关于这一加法和数乘构成一个实线性空间. 求$\mathbf{R}^+$的一组基.
+        \begin{answer}
+            分析该实线性空间，可以看出加法单位元为 1，数乘单位元为 1. 我们给出一组基：$e$，其中 $e$ 为自然对数的底数. 当然, 2，3 或者 10 都可以作为一组基. 接下来我们验证 $e$ 是 $\mathbf{R}^+$ 的基：$\forall a\in \mathbf{R}^+,\exists k=\ln a\in\mathbf{R}$，满足 $k\odot e=e^k=a$，则 $\spa(e)=\mathbf{R}^+$ 成立. 由于该向量组只有一个元素，且并非设该空间的零元 1，则 $e$ 是线性无关的. 得证.
+        \end{answer}
     \end{exgroup}
 
     \begin{exgroup}
@@ -711,8 +932,34 @@
                   \end{align*}
                   其中$l_1\neq 0$，证明：$\dfrac{k_1}{l_1}=\cdots=\dfrac{k_m}{l_m}$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 若 不全为 0. 不妨设设至少有 $k_i=0$，则有 $k_1\alpha_1+\cdots+k_{i-1}\alpha_{i-1}+k_{i+1}\alpha_{i+1}+\cdots+k_m\alpha_m=0$，并且系数不全为 0. 因此 $\alpha_1,\ldots,\alpha_{i-1},\alpha_{i+1},\ldots,\alpha_m$ 这 $m-1$ 个向量相关，与题设矛盾. 则原题得证.
+
+                \item $l_1\neq 0$，则 $l_2,\ldots,l_m$ 均不为 0.
+                      \begin{enumerate}
+                          \item 若 $k_1=\cdots=k_m=0$. 原式显然成立.
+
+                          \item 若 $k_1,\ldots,k_m$ 不全为 0. 则
+                                \begin{gather*}
+                                    l_1(k_1\alpha_1+\cdots+k_m\alpha_m)=0, \\
+                                    k_1(l_1\alpha_1+\cdots+l_m\alpha_m)=0.
+                                \end{gather*}
+                                两式相减，得
+                                \[(k_2l_1-k_1l_2)\alpha_2+\cdots+(k_ml_1-k_1l_m)\alpha_m=0,\]
+                                因为 $\alpha_2,\ldots,\alpha_m$ 线性无关. 则以上系数均为 0. 故$\dfrac {k_2}{l_2}=\dfrac {k_1}{l_1},\ldots,\dfrac {k_m}{l_m}=\dfrac {k_1}{l_1}$. 得证.
+                      \end{enumerate}
+            \end{enumerate}
+        \end{answer}
 
         \item （替换定理）设$\alpha_1,\alpha_2,\ldots,\alpha_r$线性无关，且可以被$\beta_1,\beta_2,\ldots,\beta_n$线性表示，则可以将$\beta_1,\beta_2,\ldots,\beta_n$中的$r$个向量替换成$\alpha_1,\alpha_2,\ldots,\alpha_r$后得到与$\beta_1,\beta_2,\ldots,\beta_n$等价的新向量组（注：可以使用数学归纳法证明）.
+        \begin{answer}
+            利用递推法：当 $r=1$ 时，由于 $\alpha_1$ 线性无关，可得 $\alpha_1\neq 0$. 设 $\alpha_1=\lambda_1\beta_1+\cdots+\lambda_n\beta_n$，则至少存在一个 $\lambda_i\neq 0$，不妨设 $\lambda_1\neq 0$，因此有 $\beta_1=-\vspace{1ex}\dfrac 1{\lambda_1}(-\alpha_1+\lambda_2\beta_2+\cdots+\lambda_n\beta_n)$，故 $\beta_1,\ldots,\beta_n$ 与 $\alpha_1,\beta_2,\ldots,\beta_n$ 等价.
+
+            当 $r=2$ 时，由于 $\alpha_1,\alpha_2$ 无关. 有 $\alpha_1\alpha_2\neq 0$. 根据 $r=1$ 的情况，不妨设 $\beta_1,\ldots,\beta_n$ 与 $\alpha_1,\beta_2,\ldots,\beta_n$ 等价. 因此 $\alpha_2$ 可由 $\alpha_1,\beta_2,\ldots,\beta_n$ 表出：
+            \[\alpha_2=\mu_1\alpha_1+\mu_2\beta_2+\cdots+\mu_n\beta_n.\]
+            由于 $\alpha_1,\alpha_2$ 无关，故 $\mu_2,\ldots,\mu_n$ 至少有一个非零的数. 不妨设 $\mu_2\neq 0$，同上可得$\alpha_1,\alpha_2,\beta_3,\ldots,\beta_n$ 就与 $\alpha_1,\beta_2,\ldots,\beta_n$ 等价，也与$\beta_1,\beta_2,\ldots,\beta_n$ 等价. 综上，通过递推可知，对正整数 $r$，上述结论依然成立.
+        \end{answer}
 
         \item 设线性空间$V=\mathbf{F}^n$. 证明：
         \begin{enumerate}
@@ -722,11 +969,87 @@
 
             \item 若$V$的子空间$W$的任一非零向量的零分量个数均不超过$r$，则$\dim W \leqslant r+1$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item $\alpha=(1,1,\ldots,1)^{\mathrm{T}}, W=\spa(\alpha)$,显然 $W$ 是满足条件的一维子空间.
+
+                \item 考虑反证法：若 $\dim W>1$，则 $W$ 中存在线性无关的两向量. 由条件，
+                      \[a_1,\ldots,a_n,b_1,\ldots,b_n\neq 0,\]
+                      可设 $a_1=kb_1,k\in F$，因此 $\alpha-k\beta=(0,a_2-kb-2,\ldots,a_n-kb_n)^{\mathrm{T}}\in W$. 且由于 $\alpha,\beta$ 无关，$\alpha-k\beta\neq 0$ 但存在分量为 0，这与条件矛盾. 故 $\dim W=1$.
+
+                \item 考虑反证法：若 $\dim W>r+1$，则存在 $r+2$ 个线性无关的向量，设为
+                      \begin{align*}
+                          \alpha_1     & = (a_{11},a_{12},\ldots,a_{1(r+1)},\ldots,a_{1n})^{\mathrm{T}},                 \\
+                                       & \vdotswithin{ = }                                                              \\
+                          \alpha_{r+2} & = (a_{(r+2)1},a_{(r+2)2},\ldots,a_{(r+2)(r+1)},\ldots,a_{(r+2)n})^{\mathrm{T}}.
+                      \end{align*}
+                      取这些向量的前 $r+1$ 个分量组成新的向量组：
+                      \begin{align*}
+                          \beta_1     & = (a_{11},a_{12},\ldots,a_{1(r+1)})^{\mathrm{T}},             \\
+                                      & \vdotswithin{ = }                                            \\
+                          \beta_{r+2} & = (a_{(r+2)1},a_{(r+2)2},\ldots,a_{(r+2)(r+1)})^{\mathrm{T}}.
+                      \end{align*}
+                      由于 $\beta_1,\ldots,\beta_{r+2}$ 是 $r+2$ 个 $r+1$ 维向量，其必然线性相关，则存在不全为 0 的系数 $\lambda_1,\ldots,\lambda_{r+2}$，$\lambda_1\beta_1+\cdots+\lambda_{r+2}\beta_{r+2}=0$.  由于 $\alpha_1,\ldots,\alpha_{r+2}$ 线性无关知：$\lambda_1\alpha_1+\cdots+\lambda_{r+2}\alpha_{r+2}\neq 0$，且其属于 $W$. 但其前 $r+1$ 个分量均为 0，这与条件矛盾. 故 $\dim W\leqslant r+1$ 得证.
+            \end{enumerate}
+        \end{answer}
 
         \item 设 $\mathbf{Q}(\sqrt[3]{2}) = \{a+b\sqrt[3]{2}+c\sqrt[3]{4}\mid a,b,c\in\mathbf{Q}\}$，证明 $\mathbf{Q}(\sqrt[3]{2})$ 是 $\mathbf{Q}$ 上的线性空间并求其维数.
+        \begin{answer}
+            先证明 $\mathbf{Q}(\sqrt[3]{2})$ 是 $\mathbf{Q}$ 上的线性空间：
+
+            $\mathbf{Q}(\sqrt[3]{2})$ 对通常的加法构成交换群以及其封闭性是显然的，在此不再赘述，下阐述数乘性质：
+            \begin{enumerate}
+                \item $\forall v = a+b\sqrt[3]{2}+c\sqrt[3]{4} \in \mathbf{Q}(\sqrt[3]{2}), \enspace 1 (a+b\sqrt[3]{2}+c\sqrt[3]{4}) = a+b\sqrt[3]{2}+c\sqrt[3]{4}$；
+
+                \item $\forall v = a+b\sqrt[3]{2}+c\sqrt[3]{4} \in \mathbf{Q}(\sqrt[3]{2}), \forall \lambda, \mu \in \mathbf{Q}, \enspace \lambda(\mu v) = (\lambda \mu) v$；
+
+                \item $\forall v = a+b\sqrt[3]{2}+c\sqrt[3]{4} \in \mathbf{Q}(\sqrt[3]{2}), \forall \lambda, \mu \in \mathbf{Q}, \enspace (\lambda + \mu) v = (\lambda + \mu)a + (\lambda + \mu) b\sqrt[3]{2} + (\lambda + \mu) c\sqrt[3]{4} = \lambda(a+b\sqrt[3]{2}+c\sqrt[3]{4}) + \mu(a+b\sqrt[3]{2}+c\sqrt[3]{4}) = \lambda v + \mu v$；
+
+                \item $\forall v = a_1 + b_1\sqrt[3]{2} + c_1\sqrt[3]{4}, u = a_2 + b_2\sqrt[3]{2} + c_2\sqrt[3]{4} \in \mathbf{Q}(\sqrt[3]{2}), \forall \lambda \in \mathbf{Q}, \enspace \lambda(v+u) = \lambda (a_1 + a_2) + \lambda (b_1 + b_2)\sqrt[3]{2} + \lambda (c_1 + c_2)\sqrt[3]{4} = \lambda (a_1 + b_1\sqrt[3]{2} + c_1\sqrt[3]{4}) + \lambda (a_2 + b_2\sqrt[3]{2} + c_2\sqrt[3]{4}) = \lambda v + \lambda u$；
+
+                \item （封闭性）$\forall v = a+b\sqrt[3]{2}+c\sqrt[3]{4} \in \mathbf{Q}(\sqrt[3]{2}), \forall \lambda \in \mathbf{Q}, \enspace \lambda v = \lambda a + \lambda b\sqrt[3]{2} + \lambda c\sqrt[3]{4} \in \mathbf{Q}(\sqrt[3]{2})$.
+            \end{enumerate}
+            故 $\mathbf{Q}(\sqrt[3]{2})$ 是 $\mathbf{Q}$ 上的线性空间.
+
+            下求 $\mathbf{Q}(\sqrt[3]{2})$ 的维数. 考虑找 $\mathbf{Q}(\sqrt[3]{2})$ 的一组基，我们给出 $\{1, \sqrt[3]{2}, \sqrt[3]{4}\}$，下证其为 $\mathbf{Q}(\sqrt[3]{2})$ 的一组基：
+
+            \begin{enumerate}
+                \item （线性无关）令 $k_1 + k_2 \sqrt[3]{2} + k_3 \sqrt[3]{4} = 0$，其中 $k_1, k_2, k_3 \in \mathbf{Q}$，由于左边只有第一项为有理数，故有 $k_1 = 0$，进而有 $\sqrt[3]{2} (k_2 + k_3 \sqrt[3]{2}) = 0$，又可得到 $k_2 = 0$，并且 $k_3 = 0$. 故 $\{1, \sqrt[3]{2}, \sqrt[3]{4}\}$ 线性无关.
+
+                \item （张成空间）由 $\mathbf{Q}(\sqrt[3]{2})$ 的定义易得.
+            \end{enumerate}
+            综上，$\mathbf{Q}(\sqrt[3]{2})$ 是 $\mathbf{Q}$ 上的线性空间，且 $\dim \mathbf{Q}(\sqrt[3]{2}) = 3$.
+
+        \end{answer}
 
         \item 设$\mathbf{K} \subseteq \mathbf{F} \subseteq \mathbf{E}$是三个数域，已知$\mathbf{F}$作为$\mathbf{K}$上的线性空间是$n$维的，$\mathbf{E}$作为$\mathbf{F}$上的线性空间是$m$维的，证明：$\mathbf{E}$作为$\mathbf{K}$上的线性空间是$mn$维的.
+        \begin{answer}
+            取 $\mathbf{F}(\mathbf{K})$ 的一组基 $f_1, f_2, \ldots, f_n$，$\mathbf{E}(\mathbf{F})$ 的一组基 $e_1, e_2, \ldots, e_m$，下证向量组 $B = \{f_1 e_1, f_2 e_1, \ldots, f_n e_1, f_1 e_2, f_2 e_2, \ldots, f_n e_2, \ldots, f_1 e_m, f_2 e_m, \ldots, f_n e_m\}$ 是 $\mathbf{E}(\mathbf{K})$ 的一组基：
+
+            \begin{enumerate}
+                \item （线性无关）令 $k_{11} f_1 e_1 + k_{12} f_2 e_1 + \cdots + k_{1n} f_n e_1 + k_{21} f_1 e_2 + k_{22} f_2 e_2 + \cdots + k_{2n} f_n e_2 + \cdots + k_{m1} f_1 e_m + k_{m2} f_2 e_m + \cdots + k_{mn} f_n e_m = 0$，其中 $k_{ij} \in \mathbf{K}$，则
+                    \[
+                        \sum_{i=1}^m \left(\sum_{j=1}^n k_{ij} f_j \right) e_i = 0.
+                    \]
+                    由于 $e_1, e_2, \ldots, e_n$ 是 $\mathbf{E}(\mathbf{F})$ 的一组基 $e_1, e_2, \ldots, e_m$，我们有
+                    \[
+                        \sum_{j=1}^n k_{ij} f_j = 0, \enspace \forall i = 1, 2, \ldots, m.
+                    \]
+                    而 $f_1, f_2, \ldots, f_n$ 又是 $\mathbf{F}(\mathbf{K})$ 的一组基，故 $k_{ij} = 0$，即向量组 $B$ 线性无关.
+
+                \item （张成空间）$\forall e = \mu_1 e_1 + \mu_2 e_2 + \cdots + \mu_m e_m \in \mathbf{E} \enspace (\mu_1, \mu_2, \ldots, \mu_m \in \mathbf{F})$，由于 $\mu_i \in \mathbf{F}$，故存在 $k_{ij} \in \mathbf{K}$ 使得 $\mu_i = k_{i1} f_1 + k_{i2} f_2 + \cdots + k_{in} f_n$，于是
+                    \[
+                        e = \sum_{i=1}^m \left(\sum_{j=1}^n k_{ij} f_j \right) e_i
+                          = \sum_{i=1}^m \sum_{j=1}^n k_{ij} f_j e_i.
+                    \]
+                    故 $e \in \spa B$.
+            \end{enumerate}
+            综上，$B$ 是 $\mathbf{E}(\mathbf{K})$ 的一组基，故 $\dim \mathbf{E}(\mathbf{K}) = mn$.
+        \end{answer}
 
         \item 延续上一讲对于 $\mathbf{F_4}(\mathbf{Z}_2)$ 的讨论，尝试求 $\mathbf{F_4}$ 在 $\mathbf{Z}_2$ 上的一组基及其维数，以及其中每个元素的坐标表示.
+        \begin{answer}
+
+        \end{answer}
     \end{exgroup}
 \end{exercise}

--- a/讲义/专题/9 矩阵运算进阶.tex
+++ b/讲义/专题/9 矩阵运算进阶.tex
@@ -951,7 +951,7 @@
                             \end{pmatrix}=r(A)+r(B)$.
 
                   \item 同上一问的假设，此时有
-                        \begin{align*}
+                        \[
                             \begin{pmatrix}
                                 P_1 & O \\ C & P_2
                             \end{pmatrix}
@@ -961,10 +961,10 @@
                             \begin{pmatrix}
                                 Q_1 & O \\ O & Q_2
                             \end{pmatrix}
-                             & =\begin{pmatrix}
+                             =\begin{pmatrix}
                                     E_r & O & O & O \\ O & O & O & O \\ C_{11} & C_{12} & E_s & O \\ C_{21} & C_{22} & O & O
                                 \end{pmatrix},
-                        \end{align*}
+                        \]
                         其中$\begin{pmatrix}
                                 C_{11} & C_{12} \\ C_{21} & C_{22}
                             \end{pmatrix}$是$P_2CQ_1$的一种分块. 结合$E_r$和$E_s$都是单位矩阵，因此我们可以通过初等变换消去与它们同行、同列的$C_{11},C_{12},C_{21}$，即
@@ -1138,6 +1138,20 @@
 
             \item $A+E$和$A-2E$不可能同时可逆.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 若 $ AB = kE \enspace(k \neq 0) $，则 $ A^{-1} = \dfrac{1}{k} B $. 由
+                      \[ A^2 - A - 2E = A(A - E) - 2E = O \]
+                      可得
+                      \[ A(A - E) = 2E \text{~或~} A(E - A) = -2E. \]
+                      所以
+                      \[ A^{-1} = \frac{1}{2}(A-E),\enspace (E - A)^{-1} = -\frac{1}{2}A. \]
+
+                \item 由
+                      \[  A^2 - A - 2E = (A - 2E)(A + E) = O \]
+                      可知，$ A + E $ 和 $ A - 2E $ 不能同时可逆，否则 $ A^2 - A - 2E $ 为零矩阵可逆，矛盾.
+            \end{enumerate}
+        \end{answer}
 
         \item 若$A,B$为两个$n$阶矩阵且满足$A+B=AB$，证明：
         \begin{enumerate}
@@ -1147,22 +1161,171 @@
 
             \item $r(A)=r(B)$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item \begin{align*}
+                          (A - E)(B - E) & = AB - AE - EB + E^2 \\
+                                         & = AB - A - B + E     \\
+                                         & = AB - (A + B) + E   \\
+                                         & = AB - AB + E        \\
+                                         & = E.
+                      \end{align*}
+                      所以 $ A - E $ 与 $ B - E $ 互为逆矩阵.
 
-        \item 求下列矩阵的可逆的条件与逆矩阵：$\begin{pmatrix}
-                A & B \\ O & D
-            \end{pmatrix},\enspace \begin{pmatrix}
-                O & B \\ C & D
-            \end{pmatrix}$.
+                \item 由于 $ A - E $ 与 $ B - E $ 互为逆矩阵，所以
+                      \begin{align*}
+                          (B - E)(A - E) & = E              \\
+                                         & = BA - B - A + E \\
+                                         & = BA - AB + E.
+                      \end{align*}
+                      所以 $ BA - AB = O $，即 $ AB = BA $.
+
+                \item 由 $ A = AB - B = B(A - E) $ 可得 $ r(A) \leqslant r(B) $，同理可得 $ r(B) \leqslant r(A) $，所以 $ r(A) = r(B) $.
+            \end{enumerate}
+        \end{answer}
+
+        \item 求下列矩阵的可逆的条件与逆矩阵：
+            \begin{enumerate}
+                \item $\begin{pmatrix}
+                        A & B \\ O & D
+                    \end{pmatrix}$，其中 $A$ 是 $m$ 阶方阵，$D$ 是 $n$ 阶方阵，$B$ 是 $m \times n$ 矩阵；
+
+                \item $\begin{pmatrix}
+                        O & B \\ C & D
+                    \end{pmatrix}$，其中 $B$ 是 $n$ 阶方阵，$C$ 是 $m$ 阶方阵，$D$ 是 $n \times m$ 矩阵.
+            \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 对于矩阵 $\begin{pmatrix}
+                        A & B \\ O & D
+                    \end{pmatrix}$，
+
+                    若 $A$ 不可逆，则 $r\begin{pmatrix} A \\ O \end{pmatrix} = r(A) < m$，
+                    故 $r\begin{pmatrix} A & B \\ O & D \end{pmatrix} < m+n$，原矩阵不可逆.
+
+                    若 $D$ 不可逆，则 $r\begin{pmatrix} O & D \end{pmatrix} = r(D) < n$，
+                    故 $r\begin{pmatrix} A & B \\ O & D \end{pmatrix} < m+n$，原矩阵不可逆.
+
+                    若 $A$ 与 $D$ 均可逆，利用分块矩阵初等变换，我们有
+                    \[
+                        \begin{pmatrix}
+                            A^{-1} & O \\ O & D^{-1}
+                        \end{pmatrix} \begin{pmatrix}
+                            E_m & -BD^{-1} \\ O & E_n
+                        \end{pmatrix} \begin{pmatrix}
+                            A & B \\ O & D
+                        \end{pmatrix} = E_{m+n},
+                    \]
+                    故有
+                    \[
+                        \begin{pmatrix}
+                            A & B \\ O & D
+                        \end{pmatrix}^{-1} = \begin{pmatrix}
+                            A^{-1} & O \\ O & D^{-1}
+                        \end{pmatrix} \begin{pmatrix}
+                            E_m & -BD^{-1} \\ O & E_n
+                        \end{pmatrix} = \begin{pmatrix}
+                            A^{-1} & -A^{-1}BD^{-1} \\ O & D^{-1}
+                        \end{pmatrix}.
+                    \]
+
+                \item 对于矩阵 $\begin{pmatrix}
+                        O & B \\ C & D
+                    \end{pmatrix}$，
+
+                    由于
+                    \[
+                        \begin{pmatrix}
+                            O & E_m \\ E_n & O
+                        \end{pmatrix} \begin{pmatrix}
+                            O & B \\ C & D
+                        \end{pmatrix} = \begin{pmatrix}
+                            C & D \\ O & B
+                        \end{pmatrix},
+                    \]
+
+                    而 $\begin{pmatrix} O & E_m \\ E_n & O \end{pmatrix}$ 是可逆矩阵，故
+                    \[
+                        \begin{pmatrix}
+                            O & B \\ C & D
+                        \end{pmatrix} \, \text{可逆}
+                        \iff \begin{pmatrix}
+                            C & D \\ O & B
+                        \end{pmatrix} \, \text{可逆}
+                        \iff B, C \, \text{可逆}.
+                    \]
+
+                    若 $B$ 与 $C$ 均可逆，由第一问的结论，有
+                    \[
+                        \left( \begin{pmatrix}
+                            O & E_m \\ E_n & O
+                        \end{pmatrix} \begin{pmatrix}
+                            O & B \\ C & D
+                        \end{pmatrix} \right)^{-1} = \begin{pmatrix}
+                            C^{-1} & -C^{-1}DB^{-1} \\ O & B^{-1}
+                        \end{pmatrix},
+                    \]
+
+                    故
+                    \[
+                        \begin{pmatrix}
+                            O & B \\ C & D
+                        \end{pmatrix}^{-1} = \begin{pmatrix}
+                            C^{-1} & -C^{-1}DB^{-1} \\ O & B^{-1}
+                        \end{pmatrix} \begin{pmatrix}
+                            O & E_m \\ E_n & O
+                        \end{pmatrix} = \begin{pmatrix}
+                            -C^{-1}DB^{-1} & C^{-1} \\ B^{-1} & O
+                        \end{pmatrix}.
+                    \]
+
+            \end{enumerate}
+        \end{answer}
     \end{exgroup}
 
     \begin{exgroup}
         \item 设$f(x)=1+x+\cdots+x^{m-1}$，$g(x)=1-x$，$A=\begin{pmatrix}
                 a & b \\ 0 & a
             \end{pmatrix}$，计算$f(A)g(A)$.
+        \begin{answer}
+            \begin{align*}
+                f(A) g(A) & = (E + A + A^2 + \cdots + A^{m - 1})(E - A) \\
+                          & = E - A^m = \begin{pmatrix}
+                                            1 - a^m & -mba^{m - 1} \\
+                                            0       & 1 - a^m
+                                        \end{pmatrix}.
+            \end{align*}
+        \end{answer}
 
         \item 已知矩阵$A=\begin{pmatrix}
                 1 & 0 & 4 \\ 0 & 1 & 2 \\ 0 & 1 & 2
             \end{pmatrix}$，求证：所有与$A$可交换的矩阵构成$\mathbf{M}_3(\mathbf{R})$的一个子空间，并求子空间的一组基.
+        \begin{answer}
+            求与 $ A $ 可交换的矩阵等价于求与 $ A - E $ 可交换的矩阵 $ X $. 可解得
+            \begin{align*}
+                X & = \begin{pmatrix}
+                            x_{11} & -2x_{11} - 2x_{32} + 2x_{33} & 4x_{32} \\
+                            0      & -x_{32} + x_{33}             & 2x_{32} \\
+                            0      & x_{32}                       & x_{33}
+                        \end{pmatrix} \\
+                    & = x_{11} \begin{pmatrix}
+                                1 & -2 & 0 \\
+                                0 & 0  & 0 \\
+                                0 & 0  & 0
+                            \end{pmatrix}
+                + x_{32} \begin{pmatrix}
+                            0 & -2 & 4 \\
+                            0 & -1 & 2 \\
+                            0 & 1  & 0
+                        \end{pmatrix}
+                + x_{33} \begin{pmatrix}
+                            0 & 2 & 0 \\
+                            0 & 1 & 0 \\
+                            0 & 0 & 1
+                        \end{pmatrix},
+            \end{align*}
+            其中 $ x_{11}, x_{32}, x_{33} $ 为任意实数. 由此我们也得到了 $ A $ 可交换的矩阵构成的子空间的一组基.
+        \end{answer}
 
         \item 已知矩阵$A=\begin{pmatrix}
                 1 & 0 & 1 \\ 0 & 2 & 0 \\ 1 & 0 & 1
@@ -1172,6 +1335,57 @@
 
             \item 若$AB+E=A^2+B$，求$B$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 不妨设 $ B = (b_{ij})_{3 \times 3} $ 与 $ A $ 可交换，即 $ AB = BA $，这等价于 $ (A - E)B = B(A - E) $，即
+                      \[ \begin{pmatrix}
+                                &   & 1 \\
+                                & 1 &   \\
+                              1 &   &
+                          \end{pmatrix}
+                          \begin{pmatrix}
+                              b_{11} & b_{12} & b_{13} \\
+                              b_{21} & b_{22} & b_{23} \\
+                              b_{31} & b_{32} & b_{33}
+                          \end{pmatrix} =
+                          \begin{pmatrix}
+                              b_{11} & b_{12} & b_{13} \\
+                              b_{21} & b_{22} & b_{23} \\
+                              b_{31} & b_{32} & b_{33}
+                          \end{pmatrix}
+                          \begin{pmatrix}
+                                &   & 1 \\
+                                & 1 &   \\
+                              1 &   &
+                          \end{pmatrix}. \]
+                      于是
+                      \[ \begin{pmatrix}
+                              b_{31} & b_{32} & b_{33} \\
+                              b_{21} & b_{22} & b_{23} \\
+                              b_{11} & b_{12} & b_{13}
+                          \end{pmatrix} = \begin{pmatrix}
+                              b_{11} & b_{12} & b_{13} \\
+                              b_{21} & b_{22} & b_{23} \\
+                              b_{31} & b_{32} & b_{33}
+                          \end{pmatrix} \]
+                      对应元素相等，可得 $ b_{31} = b_{13}, b_{32} = b_{12}, b_{33} = b_{11}, b_{21} = b_{23} $，即所有与 $ A $ 可交换的矩阵为
+                      \[ \begin{pmatrix}
+                              b_{11} & b_{12} & b_{13} \\
+                              b_{21} & b_{22} & b_{21} \\
+                              b_{13} & b_{12} & b_{11}
+                          \end{pmatrix}, \]
+                      其中 $ b_{11}, b_{12}, b_{13}, b_{21}, b_{22} $ 为任意实数.
+
+                \item 由于 $ AB + E = A^2 + B $，所以
+                      \[ (A - E)B = A^2 - E = (A - E)(A + E). \]
+                      又由于 $ |A - E| = -1 \neq 0 $，所以 $ A - E $ 可逆，进而
+                      \[ B = A + E = \begin{pmatrix}
+                              2 & 0 & 1 \\
+                              0 & 3 & 0 \\
+                              1 & 0 & 2
+                          \end{pmatrix}. \]
+            \end{enumerate}
+        \end{answer}
 
         \item 设$A \in \mathbf{F}^{n \times n}$，令$C(A)=\{B \in \mathbf{F}^{n \times n} \mid AB=BA\}$.
         \begin{enumerate}
@@ -1181,6 +1395,20 @@
 
             \item 当$A$为对角线上元素互不相等的对角阵时，求$C(A)$的维数和一组基.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 首先有 $ E \in C(A) $，所以 $ C(A) $ 非空. $ \forall B_1, B_2 \in C(A), \lambda \in \mathbf{F} $，有
+                      \begin{gather*}
+                          A(B_1 + B_2) = AB_1 + AB_2 = B_1A + B_2A = (B_1 + B_2)A \\
+                          A(\lambda B_1) = \lambda AB_1 = \lambda B_1A = (\lambda B_1)A.
+                      \end{gather*}
+                      所以 $ C(A) $ 是 $ \mathbf{F}^{n \times n} $ 的子空间.
+
+                \item $ C(E) = \mathbf{F}^{n \times n} $.
+
+                \item 我们有结论：$ C(A) $ 为全体对角矩阵构成的集合. 故 $ \dim C(A) = n $. 基矩阵 $ B_k = (b_{ij})_{n \times n} $，其中 $ b_{ij} = \delta_{ij} \delta_{jk} $. $ B_1, B_2, \ldots, B_n $ 为一组基.
+            \end{enumerate}
+        \end{answer}
 
         \item 设$A$是$n$阶矩阵，$A^k=O$对某个正整数$k$成立，求证下列方阵可逆，并求它们的逆：
         \begin{enumerate}
@@ -1190,25 +1418,135 @@
 
             \item $E+A+\dfrac{1}{2!}A^2+\cdots+\dfrac{1}{(k-1)!}A^{k-1}$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 由 $ A^k = O $ 有
+                      \[ E = E - A^k = (E - A)(E + A + \cdots + A^{k - 1}). \]
+                      故 $ E - A $ 可逆，且
+                      \[ (E - A)^{-1} = E + A + \cdots + A^{k - 1}. \]
+
+                \item 若 $ k $ 为偶数，设 $ k = 2m $，由 $ A^k = O $ 有
+                      \[ E = E - A^{2m} = (E + A)(E - A)(E + A^2 + A^4 + \cdots + A^{2m - 2}). \]
+                      故 $ E + A $ 可逆，且
+                      \[ (E + A)^{-1} = (E - A)(E + A^2 + A^4 + \cdots + A^{2m - 2}). \]
+
+                      若 $ k $ 为奇数，设 $ k = 2m + 1 $，由 $ A^k = O $ 有
+                      \[ E = E - A^{2m + 1} = (E - A)(E + A + A^2 + \cdots + A^{2m - 1} + A^{2m}) \]
+                      故 $ E - A $ 可逆，且
+                      \[ (E - A)^{-1} = E + A + A^2 + \cdots + A^{2m - 1} + A^{2m} \]
+
+                \item 由于 $ A^k = O $，于是
+                      \[ e^A = E + A + \frac{1}{2!} A^2 + \cdots + \frac{1}{(k - 1)!} A^{k - 1}. \]
+                      由 $ e^A e^{-A} = E $ 知 $ E + A + \dfrac{1}{2!} A^2 + \cdots + \dfrac{1}{(k - 1)!} A^{k - 1} $ 可逆，且
+                      \[ (E + A + \frac{1}{2!} A^2 + \cdots + \frac{1}{(k - 1)!} A^{k - 1})^{-1} = e^{-A}. \]
+            \end{enumerate}
+        \end{answer}
 
         \item 设$A=\begin{pmatrix}
                 1      & \cdots & 1      \\
                 \vdots & \ddots & \vdots \\
                 1      & \cdots & 1
-            \end{pmatrix}$，求：
+            \end{pmatrix}_{n \times n}$，求：
         \begin{enumerate}
             \item 一个二次实系数多项式$f(x)=ax^2+bx$，使得$f(A)=O$；
-            \item $A^100$；
+            \item $A^{100}$；
             \item $(A+E)^3$；
             \item $(A+E)^{-1}$.
         \end{enumerate}
-        % 新题，需要答案
+        \begin{answer}
+            \begin{enumerate}
+                \item $A^2 = \begin{pmatrix}
+                        n      & \cdots & n      \\
+                        \vdots & \ddots & \vdots \\
+                        n      & \cdots & n
+                    \end{pmatrix}$，故 $A^2 - nA = O$，令 $a=1, b=-n$ 即可.
 
-        \item 当$A$和$D$可逆时，通过分块矩阵初等变换求$P=\begin{pmatrix}A & B \\ O & D\end{pmatrix}$的逆矩阵.
+                \item 利用 $A^2 = nA$，有
+                    \[
+                        A^{100} = n A^{99} = n^2 A^{98} = \cdots = n^{99} A = \begin{pmatrix}
+                            n^{99} & \cdots & n^{99} \\
+                            \vdots & \ddots & \vdots \\
+                            n^{99} & \cdots & n^{99}
+                        \end{pmatrix}.
+                    \]
 
-        \item 利用列向量线性相关性，证明矩阵秩不等式：\[|r(A)-r(B)|\leqslant r(A\pm B) \leqslant r(A)+r(B)\]
+                \item 利用 $A^2 = nA$，有
+                    \begin{align*}
+                        (A+E)^3 &= A^3 + 3A^2 + 3A + E \\
+                                &= (n^2 + 3n + 3)A + E \\
+                                &= \begin{pmatrix}
+                                    n^2 + 3n + 4 & n^2 + 3n + 3 & \cdots & n^2 + 3n + 3 \\
+                                    n^2 + 3n + 3 & n^2 + 3n + 4 & \cdots & n^2 + 3n + 3 \\
+                                    \vdots & \vdots & \ddots & \vdots \\
+                                    n^2 + 3n + 3 & n^2 + 3n + 3 & \cdots & n^2 + 3n + 4
+                                \end{pmatrix}.
+                    \end{align*}
+
+                \item 为得到 $(A+E)^{-1}$，我们需要构造另一个含 $A$ 的一次多项式，该式乘以 $A+E$ 后出现 $A^2 - nA$，以利用条件 $A^2 = nA$. 观察发现所需的多项式为 $A - (n+1)E$：
+                    \[
+                        (A+E)(A-(n+1)E) = A^2 - nA -(n+1)E = -(n+1)E,
+                    \]
+
+                    于是
+                    \[
+                        (A+E)^{-1} = -\frac{1}{n+1} A + E = \begin{pmatrix}
+                            \dfrac{n}{n+1}  & -\dfrac{1}{n+1} & \cdots & -\dfrac{1}{n+1} \\[2em]
+                            -\dfrac{1}{n+1} & \dfrac{n}{n+1}  & \cdots & -\dfrac{1}{n+1} \\[2em]
+                            \vdots          & \vdots          & \ddots & \vdots          \\[2em]
+                            -\dfrac{1}{n+1} & -\dfrac{1}{n+1} & \cdots & \dfrac{n}{n+1}
+                        \end{pmatrix}.
+                    \]
+            \end{enumerate}
+        \end{answer}
+
+        \item 当 $A$ 和 $D$ 可逆时，通过分块矩阵初等变换求 $P=\begin{pmatrix}A & B \\ O & D\end{pmatrix}$ 的逆矩阵.
+        \begin{answer}
+            见本章 A 组第 3 题的答案，此处不再赘述.
+        \end{answer}
+
+        \item 利用列向量线性相关性，证明矩阵秩不等式：\[|r(A)-r(B)|\leqslant r(A\pm B) \leqslant r(A)+r(B).\]
+        \begin{answer}
+            我们先证明 $r(A \pm B) \leqslant r(A)+r(B)$：
+
+            设 $A = (\alpha_1, \alpha_2, \ldots, \alpha_n), B = (\beta_1, \beta_2, \ldots, \beta_n)$，并设 $r(A) = r, r(B) = s$. 不妨设 $A$ 的列向量组的一个极大线性无关组为 $\alpha_1, \alpha_2, \ldots, \alpha_r$，$B$ 的列向量组的一个极大线性无关组为 $\beta_1, \beta_2, \ldots, \beta_s$.
+
+            取 $\alpha_1, \alpha_2, \ldots, \alpha_r, \beta_1, \beta_2, \ldots, \beta_s$ 的一个极大线性无关组 $\gamma_1, \gamma_2, \ldots, \gamma_p$，则 $p \leqslant r+s$. 该极大线性无关组可以线性表示 $A$ 与 $B$ 的列向量组，因此可以线性表示 $\alpha_1 \pm \beta_1, \alpha_2 \pm \beta_2, \ldots, \alpha_n \pm \beta_n$，即 $A \pm B$ 的列向量组，故
+            \[
+                r(A \pm B) \leqslant p \leqslant r+s = r(A) + r(B).
+            \]
+
+            再证明 $|r(A) - r(B)| \leqslant r(A \pm B)$：
+
+            不妨设 $r(A) \geqslant r(B)$，即证 $r(A) - r(B) \leqslant r(A \pm B)$. 由于
+            \begin{align*}
+                r(A) &\leqslant r(A + B) + r(-B) = r(A + B) + r(B), \\
+                r(A) &\leqslant r(A - B) + r(B),
+            \end{align*}
+
+            即有
+            \[
+                r(A) - r(B) \leqslant r(A \pm B).
+            \]
+
+            同理可得若 $r(A) \leqslant r(B)$，则 $r(B) - r(A) \leqslant r(A \pm B)$. 综上，结论成立.
+
+        \end{answer}
 
         \item 设$B$是$3 \times 1$矩阵，$C$是$1 \times 3$矩阵，证明：$r(BC) \leqslant 1$. 反之，若$A$是秩为1的$3 \times 3$矩阵，证明：存在$3 \times 1$矩阵$B$和$1 \times 3$矩阵$C$，使得$A = BC$.
+        \begin{answer}
+            若 $B$ 是 $3 \times 1$ 矩阵，$C$ 是 $1 \times 3$ 矩阵，利用秩不等式 $r(BC) \leqslant \min\{r(B), r(C)\}$，以及 $r(B) \leqslant 1, r(C) \leqslant 1$，有
+            \[
+                r(BC) \leqslant 1.
+            \]
+
+            反之，若 $A$ 是秩为 $1$ 的 $3 \times 3$ 矩阵，则 $A$ 任意两个列向量线性相关. 任取其中的一个非零列向量 $\beta$（$r(A)=1$ 保证其存在），则 $A$ 可表示为
+            \[
+                A = (a_1 \beta, a_2 \beta, a_3 \beta) = \beta (a_1 , a_2 , a_3).
+            \]
+
+            令 $B = \beta, C = (a_1 , a_2 , a_3)$，即有 $A = BC$.
+
+        \end{answer}
 
         \item 设$\alpha,\beta$为$n$维列向量，且$A=\alpha\alpha^\mathrm{T}+\beta\beta^\mathrm{T}$.
         \begin{enumerate}
@@ -1216,14 +1554,115 @@
 
             \item 若$\alpha,\beta$线性相关，证明：$r(A) \leqslant 1$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 设 $\alpha = (a_1, a_2, \ldots, a_n)^\mathrm{T}$，$\beta = (b_1, b_2, \ldots, b_n)^\mathrm{T}$，则
+                    \begin{align*}
+                        \alpha \alpha^\mathrm{T} &= (a_1 \alpha, a_2 \alpha, \ldots, a_n \alpha), \\
+                        \beta \beta^\mathrm{T} &= (b_1 \beta, b_2 \beta, \ldots, b_n \beta).
+                    \end{align*}
+                    故 $\alpha \alpha^\mathrm{T}$ 和 $\beta \beta^\mathrm{T}$ 的任意两个列向量线性相关，$r\left(\alpha \alpha^\mathrm{T}\right) \leqslant 1$，$r\left(\beta \beta^\mathrm{T}\right) \leqslant 1$，故
+                    \[
+                        r\left(\alpha \alpha^\mathrm{T} + \beta \beta^\mathrm{T}\right) \leqslant r\left(\alpha \alpha^\mathrm{T}\right) + r\left(\beta \beta^\mathrm{T}\right) \leqslant 2.
+                    \]
 
-        \item 设$A$和$B$是两个$n$阶实方阵，证明：$r(A)=r(AB)$当且仅当存在$n$阶实方阵$C$使得$A=ABC$. % 新题，需要答案
+                \item 若 $\alpha = 0$，则 $A = \beta \beta^\mathrm{T}$，故 $r(A) \leqslant 1$.
+
+                    若 $\alpha \neq 0$，由于 $\alpha, \beta$ 线性相关，存在常数 $k$，使得 $\beta = k \alpha$，则
+                    \[
+                        A = \alpha \alpha^\mathrm{T} + (k \alpha)(k \alpha)^\mathrm{T} = (k^2 + 1) \alpha \alpha^\mathrm{T},
+                    \]
+                    故 $r(A) \leqslant 1$.
+            \end{enumerate}
+        \end{answer}
+
+        \item 设$A$和$B$是两个$n$阶实方阵，证明：$r(A)=r(AB)$当且仅当存在$n$阶实方阵$C$使得$A=ABC$.
+        \begin{answer}
+            \begin{enumerate}
+                \item 存在 $n$ 阶实方阵 $C$ 使得 $A = ABC \implies r(A) = r(AB)$：
+                    由秩不等式 $r(AB) \leqslant \min\{r(A), r(B)\}$，我们有
+                    \[
+                        r(ABC) \leqslant r(AB) \leqslant r(A).
+                    \]
+
+                    而由 $A=ABC$ 可知 $r(A) = r(ABC)$，故 $r(A) = r(AB)$.
+
+                \item $r(A) = r(AB) \implies$ 存在 $n$ 阶实方阵 $C$ 使得 $A = ABC$：
+                    设 $A = (\alpha_1, \alpha_2, \ldots, \alpha_n)$，$B = (b_{ij})_{n \times n}$，则
+                    \begin{align*}
+                        AB &= (\alpha_1, \alpha_2, \ldots, \alpha_n) \begin{pmatrix}
+                                  b_{11} & b_{12} & \cdots & b_{1n} \\
+                                  b_{21} & b_{22} & \cdots & b_{2n} \\
+                                  \vdots & \vdots & \ddots & \vdots \\
+                                  b_{n1} & b_{n2} & \cdots & b_{nn}
+                              \end{pmatrix} \\
+                           &= \left( \sum_{i=1}^n b_{i1} \alpha_i, \sum_{i=1}^n b_{i2} \alpha_i, \ldots, \sum_{i=1}^n b_{in} \alpha_i \right).
+                    \end{align*}
+                    设 $\gamma_j = \sum_{i=1}^n b_{ij} \alpha_i$. 由于 $r(A) = r(AB)$，$\alpha_1, \alpha_2, \ldots, \alpha_n$ 与 $\gamma_1, \gamma_2, \ldots, \gamma_n$ 等价，故存在 $C = (k_{ij})_{n \times n}$，使得
+                    \begin{align*}
+                        (\alpha_1, \alpha_2, \ldots, \alpha_n)
+                        &= (\gamma_1, \gamma_2, \ldots, \gamma_n) \begin{pmatrix}
+                            k_{11} & k_{12} & \cdots & k_{1n} \\
+                            k_{21} & k_{22} & \cdots & k_{2n} \\
+                            \vdots & \vdots & \ddots & \vdots \\
+                            k_{n1} & k_{n2} & \cdots & k_{nn}
+                        \end{pmatrix} \\
+                        &= (\gamma_1, \gamma_2, \ldots, \gamma_n) C,
+                    \end{align*}
+                    即 $A = ABC$.
+            \end{enumerate}
+        \end{answer}
 
         \item 证明如下结论：
         \begin{enumerate}
             \item 若存在正整数$m$使得$r(A^m)=r(A^{m+1})$，则必有$r(A^m)=r(A^{m+1})=r(A^{m+2})=\cdots$；
             \item 设$A$为$n$阶方阵，证明：$r(A^n)=r(A^{n+1})=r(A^{n+2})=\cdots$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 该问题可以转换为线性映射的像空间停止收缩的问题：
+                    设 $A_{n \times n} = M(\sigma)$，则 $r(A^m) = r(A^{m+1})$ 等价于 $\dim \im \sigma^m = \dim \im \sigma^{m+1}$.
+
+                    任取 $k \geqslant 2$，由于 $\forall \beta \in \im \sigma^{k-1}$，存在 $\alpha \in \mathbf{F}^n$，使得 $\beta = \sigma^k(\alpha) = \sigma^{k-1}(\sigma(\alpha)) \in \im \sigma^{k-1}$，我们有 $\im \sigma^k \subseteq \im \sigma^{k-1}$，即
+                    \[
+                        \mathbf{F}^n \supseteq \im \sigma \supseteq \im \sigma^2 \supseteq \cdots \supseteq \im \sigma^m \supseteq \im \sigma^{m+1} \supseteq \cdots,
+                    \]
+
+                    又 $\dim \im \sigma^m = \dim \im \sigma^{m+1}$，故
+                    \[
+                        \im \sigma^{m+1} = \im \sigma^m.
+                    \]
+
+                    假设 $n=k-1 \enspace (k > m)$ 时，有 $\im \sigma^n = \im \sigma^{n+1}$ 成立，下证 $n=k$ 时该结论也成立：
+
+                    $\forall \gamma \in \im \sigma^k$，存在 $\alpha \in \mathbf{F}^n$，使得 $\gamma = \sigma^k(\alpha) = \sigma(\sigma^{k-1}(\alpha))$. 设 $\beta = \sigma^{k-1}(\alpha) \in \im \sigma^{k-1} = \im \sigma^k$，则 $\gamma = \sigma(\beta) \in \im \sigma^{k+1}$，故 $\im \sigma^k \subseteq \im \sigma^{k+1}$，而另一个方向的包含关系已经证明，所以有
+                    \[
+                        \im \sigma^{k+1} = \im \sigma^k.
+                    \]
+
+                    因此，
+                    \[
+                        \im \sigma^m = \im \sigma^{m+1} = \im \sigma^{m+2} = \cdots.
+                    \]
+
+                    显然有
+                    \[
+                        r(A^m) = r(A^{m+1}) = r(A^{m+2}) = \cdots.
+                    \]
+
+                \item 反证法. 假设 $r(A^n) \neq r(A^{n+1})$，则由 $\im \sigma^{n+1} \subseteq \im \sigma^n$，有 $r(A^n) > r(A^{n+1}) \geqslant 0$.
+                    若存在 $k < n$ 使得 $r(A^k) = r(A^{k+1})$，则由第一问可知 $r(A^n) = r(A^{n+1})$，矛盾，故不存在这样的 $k$，即
+                    \[
+                        n > r(A) > r(A^2) > \cdots > r(A^{n-1}) > r(A^n) > r(A^{n+1}) \geqslant 0,
+                    \]
+
+                    由于秩只能是非负整数，上式不可能成立. 故有 $r(A^n) = r(A^{n+1})$. 再由第一问可得
+                    \[
+                        r(A^n) = r(A^{n+1}) = r(A^{n+2}) = \cdots.
+                    \]
+
+            \end{enumerate}
+        \end{answer}
     \end{exgroup}
 
     \begin{exgroup}
@@ -1233,6 +1672,65 @@
                 b_n=2a_{n-1}+4b_{n-1}+2^n
             \end{cases}\]
         求$\{a_n\},\{b_n\}$的通项公式.
+        \begin{answer}
+            设 $v_n = (a_n, b_n, 2^n)^\mathrm{T}$，则递推式可化为
+            \[
+                v_n = \begin{pmatrix}
+                    3 & 1 & 1 \\ 2 & 4 & 2 \\ 0 & 0 & 2
+                \end{pmatrix} v_{n-1},
+            \]
+            其中 $v_0 = (-1, 3, 1)^\mathrm{T}$.
+
+            设 $A = \begin{pmatrix}
+                3 & 1 & 1 \\ 2 & 4 & 2 \\ 0 & 0 & 2
+            \end{pmatrix}$，则
+            \[
+                v_n = A^n v_0.
+            \]
+
+            下面我们求 $A^n$. 注意到
+            \[
+                A = 2E + \begin{pmatrix}
+                    1 & 1 & 1 \\ 2 & 2 & 2 \\ 0 & 0 & 0
+                  \end{pmatrix}
+                  = 2E + \begin{pmatrix}
+                      1 \\ 2 \\ 0
+                  \end{pmatrix} \begin{pmatrix}
+                      1 & 1 & 1
+                  \end{pmatrix}.
+            \]
+
+            令 $\alpha = (1, 2, 0)^\mathrm{T}, \beta^\mathrm{T} = (1, 0, 2), B=\alpha \beta^\mathrm{T}$，则
+            \[
+                B^n = \left( \alpha \beta^\mathrm{T} \right)^n = \alpha \left( \beta^\mathrm{T} \alpha \right)^{n-1} \beta^\mathrm{T} = \tr(B)^{n-1} B = 3^{n-1} B.
+            \]
+
+            此时我们有
+            \begin{align*}
+                A^n &= (2E + B)^n \\
+                    &= \tbinom{n}{0} 2^n E + \tbinom{n}{1} 2^{n-1} B + \tbinom{n}{2} 2^{n-2} B^2 + \cdots + \tbinom{n}{n} B^n \\
+                    &= 2^n E + \left(\tbinom{n}{1} 2^{n-1} 3^0 + \tbinom{n}{2} 2^{n-2} 3^1 + \cdots + \tbinom{n}{n} 2^0 3^{n-1} \right) B \\
+                    &= 2^n E - \frac{2^n}{3} B + \frac{1}{3} \left(\tbinom{n}{0} 2^n 3^0 + \tbinom{n}{1} 2^{n-1} 3^1 + \cdots + \tbinom{n}{n} 2^0 3^{n-1} \right) B \\
+                    &= 2^n E + \frac{5^n - 2^n}{3} B \\
+                    &= \frac{1}{3} \begin{pmatrix}
+                        5^n + 2 \cdot 2^n & 5^n - 2^n         & 5^n - 2^n    \\
+                        2(5^n - 2^n)      & 2 \cdot 5^n + 2^n & 2(5^n - 2^n) \\
+                        0                 & 0                 & 3 \cdot 2^n
+                    \end{pmatrix}.
+            \end{align*}
+
+            代入 $v_n = A^n v_0$，有
+            \[
+                v_n = \begin{pmatrix}
+                    5^n - 2 \cdot 2^n \\
+                    2 \cdot 5^n + 2^n \\
+                    2^n
+                \end{pmatrix}.
+            \]
+
+            所以 $a_n = 5^n - 2 \cdot 2^n, b_n = 2 \cdot 5^n + 2^n$.
+
+        \end{answer}
 
         \item 设$n\geqslant 3$，证明下列矩阵不可逆：
         \[A=\begin{pmatrix}
@@ -1247,6 +1745,39 @@
                 \vdots   & \vdots   & \ddots & \vdots   \\
                 1+x_ny_1 & 1+x_ny_2 & \cdots & 1+x_ny_n
             \end{pmatrix}.\]
+        \begin{answer}
+            \begin{enumerate}
+                \item 可以将 $A$ 拆成一个 $n \times 2$ 矩阵与一个 $2 \times n$ 矩阵的乘积：
+                    \[
+                        A = \begin{pmatrix}
+                            \cos \alpha_1 & \sin \alpha_1 \\
+                            \cos \alpha_2 & \sin \alpha_2 \\
+                            \vdots        & \vdots        \\
+                            \cos \alpha_n & \sin \alpha_n
+                        \end{pmatrix} \begin{pmatrix}
+                            \cos \beta_1 & \cos \beta_2 & \cdots & \cos \beta_n \\
+                            \sin \beta_1 & \sin \beta_2 & \cdots & \sin \beta_n
+                        \end{pmatrix}.
+                    \]
+                    故由秩不等式 $r(AB) \leqslant \min\{r(A), r(B)\}$，有 $r(A) \leqslant 2 < n$，故 $A$ 不可逆.
+
+                \item 可以将 $A$ 拆成两个秩为 $1$ 的矩阵的和：
+                    \[
+                        A = \begin{pmatrix}
+                            1      & 1      & \cdots & 1      \\
+                            1      & 1      & \cdots & 1      \\
+                            \vdots & \vdots & \ddots & \vdots \\
+                            1      & 1      & \cdots & 1
+                        \end{pmatrix} + \begin{pmatrix}
+                            x_1 y_1 & x_1 y_2 & \cdots & x_1 y_n \\
+                            x_2 y_1 & x_2 y_2 & \cdots & x_2 y_n \\
+                            \vdots  & \vdots  & \ddots & \vdots  \\
+                            x_n y_1 & x_n y_2 & \cdots & x_n y_n
+                        \end{pmatrix},
+                    \]
+                    故由秩不等式 $r(A+B) \leqslant r(A)+r(B)$，有 $r(A) \leqslant 1 + 1 = 2 < n$，故 $A$ 不可逆.
+            \end{enumerate}
+        \end{answer}
 
         \item 证明以下两个命题：
         \begin{enumerate}
@@ -1266,8 +1797,77 @@
                             &   &   &        & 0
                       \end{pmatrix}$可交换的矩阵$A$都可以写成$J$的一个多项式，即$A=a_{11}E+a_{12}J+a_{13}J^2+\cdots+a_{1n}J^{n-1}$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 设 $B = \begin{pmatrix}
+                        b_{11} & b_{12} & \cdots & b_{1n} \\
+                        b_{21} & b_{22} & \cdots & b_{2n} \\
+                        \vdots & \vdots & \ddots & \vdots \\
+                        b_{n1} & b_{n2} & \cdots & b_{nn}
+                    \end{pmatrix}$ 与 $I$ 可交换，即 $BI=IB$，则
+                    \[
+                        \begin{pmatrix}
+                            b_{1n} & b_{11} & b_{12} & \cdots & b_{1,n-1} \\
+                            b_{2n} & b_{21} & b_{22} & \cdots & b_{2,n-1} \\
+                            b_{3n} & b_{31} & b_{32} & \cdots & b_{3,n-1} \\
+                            \vdots & \vdots & \vdots &        & \vdots    \\
+                            b_{n-1,n} & b_{n-1,1} & b_{n-1,2} & \cdots & b_{n-1,n-1} \\
+                            b_{nn} & b_{n1} & b_{n2} & \cdots & b_{n,n-1}
+                        \end{pmatrix} = \begin{pmatrix}
+                            b_{21} & b_{22} & b_{23} & \cdots & b_{2n} \\
+                            b_{31} & b_{32} & b_{33} & \cdots & b_{3n} \\
+                            b_{41} & b_{42} & b_{43} & \cdots & b_{4n} \\
+                            \vdots & \vdots & \vdots &        & \vdots \\
+                            b_{n1} & b_{n2} & b_{n3} & \cdots & b_{nn} \\
+                            b_{11} & b_{12} & b_{13} & \cdots & b_{1n}
+                        \end{pmatrix},
+                    \]
+                    逐一对照两矩阵中的对应元素，可得
+                    \begin{align*}
+                        b_{1n} &= b_{21} = b_{32} = \cdots = b_{n,n-1}, \\
+                        b_{1,n-1} &= b_{2n} = b_{31} = \cdots = b_{n,n-2}, \\
+                        &\vdotswithin{=} \\
+                        b_{11} &= b_{22} = b_{33} = \cdots = b_{nn}.
+                    \end{align*}
+                    第 $k$ 行等式对应了 $I^{n-k}$，故与 $I$ 可交换的矩阵都可以写成
+                    \[
+                        a_{11}E + a_{12}I + a_{13}I^2 + \cdots + a_{1n}I^{n-1}.
+                    \]
+
+                \item 按照与第一问相同的方法进行操作，即可得到结果.
+            \end{enumerate}
+        \end{answer}
 
         \item 证明：若$n$阶矩阵$A$的各阶左上角子块矩阵都可逆，则存在$n$阶下三角矩阵$B$，使得$BA$为上三角矩阵.
+        \begin{answer}
+            下使用数学归纳法证明该命题. 对于 $n=1$ 的情况，取 $B=E_1$ 即可保证 $BA$ 为上三角矩阵. 现在假设命题对 $n-1$ 阶满足条件的矩阵均成立，下证命题对 $n$ 阶满足条件的矩阵也成立：
+
+            设 $A_n = \begin{pmatrix}
+                A_{n-1} & \beta \\
+                \alpha  & a_{nn}
+            \end{pmatrix}$，其中 $A_{n-1}$ 是 $n-1$ 阶方阵，满足各阶左上角子块矩阵都可逆. 由归纳假设可知存在 $n-1$ 阶下三角矩阵 $B_{n-1}$，使得 $C_{n-1} = B_{n-1}A_{n-1}$ 为上三角矩阵. 下面我们构造 $n$ 阶下三角矩阵 $B_n$：令
+            \[
+                B_n = \begin{pmatrix}
+                    B_{n-1} & \mathbf{0} \\
+                    \gamma  & 1
+                \end{pmatrix},
+            \]
+            我们要使
+            \[
+                C_n = B_n A_n = \begin{pmatrix}
+                    B_{n-1} & \mathbf{0} \\
+                    \gamma  & 1
+                \end{pmatrix} \begin{pmatrix}
+                    A_{n-1} & \beta \\
+                    \alpha  & a_{nn}
+                \end{pmatrix} = \begin{pmatrix}
+                    C_{n-1}                 & B_{n-1} \beta         \\
+                    \gamma A_{n-1} + \alpha & \gamma \beta + a_{nn}
+                \end{pmatrix}
+            \]
+            为上三角矩阵，只需令 $\gamma A_{n-1} + \alpha = 0$ 即可. 由于 $A_{n-1}$ 可逆，故对任意 $\alpha$ 都有对应的 $\gamma$ 存在，于是 $B_n$ 存在. 因此，命题对 $n$ 阶矩阵也成立.
+
+        \end{answer}
 
         \item 设$A$是数域$\mathbf{F}$上的$n$阶可逆矩阵，把$A$和$A^{-1}$做如下分块：
         \[A=\begin{pmatrix}
@@ -1276,10 +1876,150 @@
                 B_{11} & B_{12} \\ B_{21} & B_{22}
             \end{pmatrix}\]
         其中$A_{11}$是$l \times k$矩阵，$B_{11}$是$k \times l$矩阵，$l$，$k$是小于$n$的正整数. 用$W$表示$A_{12}X=0$的解空间，$U$表示$B_{12}Y=0$的解空间，其中$X$和$Y$为列向量，证明$W$与$U$同构.
+        \begin{answer}
+            证明：$ \forall \alpha \in W,\enspace A_{12} \alpha = \vec{0} $.
+            \begin{align*}
+                \begin{pmatrix} O_{k \times 1} \\ \alpha \end{pmatrix}
+                & = A^{-1}A \begin{pmatrix} O_{k \times 1} \\ \alpha \end{pmatrix} = A^{-1} \begin{pmatrix} A_{11} & A_{12} \\ A_{21} & A_{22} \end{pmatrix} \begin{pmatrix} O_{k \times 1} \\ \alpha \end{pmatrix} = A^{-1} \begin{pmatrix} O_{l \times 1} \\ A_{22} \alpha \end{pmatrix} \\
+                & = \begin{pmatrix} B_{11} & B_{12} \\ B_{21} & B_{22} \end{pmatrix} \begin{pmatrix} O_{l \times 1} \\ A_{22} \alpha \end{pmatrix} = \begin{pmatrix} B_{12} A_{22} \alpha \\ B_{22} A_{22} \alpha \end{pmatrix}.
+            \end{align*}
+            故 $ B_{12} A_{22} \alpha = \vec{0} $，故我们可以推测如下定义：$ \sigma \in \mathcal{L}(W,U),\enspace \sigma(\alpha) = A_{22} \alpha $.
+            只需证明 $ \sigma $ 是单射且满射即可.
 
-        \item 证明 Schur补的商等式 $A/B=(A/C)/(B/C)$% 新题，需要答案
+            单射：$ \sigma(\alpha) = \sigma(\beta) \implies A_{22}(\alpha - \beta) = \vec{0} $. 又有 $ A_{12} \alpha = A_{12} \beta = \vec{0} \implies A_{12}( \alpha - \beta) = \vec{0} $. 故 $ \begin{pmatrix} A_{12} \\ A_{22} \end{pmatrix} (\alpha - \beta) = \vec{0} $. 由于 $ \begin{pmatrix} A_{12} \\ A_{22} \end{pmatrix} $ 列满秩（$ A $ 可逆），故 $ \alpha = \beta $.
+
+            满射：$ \forall \gamma \in U,\enspace B_{12} \gamma = \vec{0} $.
+            \begin{align*}
+                \begin{pmatrix} O_{l \times 1} \\ \gamma \end{pmatrix}
+                & = A A^{-1} \begin{pmatrix} O_{l \times 1} \\ \gamma \end{pmatrix} = A \begin{pmatrix} B_{11} & B_{12} \\ B_{21} & B_{22} \end{pmatrix} \begin{pmatrix} O_{l \times 1} \\ \gamma \end{pmatrix}      \\
+                & = A \begin{pmatrix} O_{k \times 1} \\ B_{22} \gamma \end{pmatrix} = \begin{pmatrix} A_{11} & A_{12} \\ A_{21} & A_{22} \end{pmatrix} \begin{pmatrix} O_{k \times 1} \\ B_{22} \gamma \end{pmatrix} \\
+                & = \begin{pmatrix} A_{12} B_{22} \gamma \\ A_{22} B_{22} \gamma \end{pmatrix}.
+            \end{align*}
+            故 $ \exists B_{22} \gamma \in W,\enspace A_{22} B_{22} \gamma = \gamma \in U $.
+        \end{answer}
+
+        \item 证明 Schur 补的商等式 $A/B=(A/C)/(B/C)$，其中 $A,B,C$ 均为可逆矩阵，且 $B$ 为 $A$ 的主子矩阵，$C$ 为 $B$ 的主子矩阵.
+        \begin{answer}
+            设 $A = \begin{pmatrix}
+                    A_{11} & A_{12} & A_{13} \\
+                    A_{21} & A_{22} & A_{23} \\
+                    A_{31} & A_{32} & A_{33}
+                \end{pmatrix}$，$B = \begin{pmatrix}
+                    A_{11} & A_{12} \\
+                    A_{21} & A_{22}
+                \end{pmatrix}$，$C = A_{11}$，则根据 Schur 补的定义，有
+                \begin{align*}
+                    A/C &= \begin{pmatrix}
+                        A_{22} & A_{23} \\
+                        A_{32} & A_{33}
+                    \end{pmatrix} - \begin{pmatrix}
+                        A_{21} \\ A_{31}
+                    \end{pmatrix} A_{11}^{-1} \begin{pmatrix}
+                        A_{12} & A_{13}
+                    \end{pmatrix} \\
+                    &= \begin{pmatrix}
+                        A_{22} - A_{21} A_{11}^{-1} A_{12} & A_{23} - A_{21} A_{11}^{-1} A_{13} \\
+                        A_{32} - A_{31} A_{11}^{-1} A_{12} & A_{33} - A_{31} A_{11}^{-1} A_{13}
+                    \end{pmatrix},
+                \end{align*}
+                \[
+                    A/B = A_{33} - \begin{pmatrix}
+                        A_{31} & A_{32}
+                    \end{pmatrix} \begin{pmatrix}
+                        A_{11} & A_{12} \\
+                        A_{21} & A_{22}
+                    \end{pmatrix}^{-1} \begin{pmatrix}
+                        A_{13} \\ A_{23}
+                    \end{pmatrix}, \enspace
+                    B/C = A_{22} - A_{21} A_{11}^{-1} A_{12}.
+                \]
+
+                设 $P_{ij} = A_{ij} - A_{i1} A_{11}^{-1} A_{1j} \enspace (i=2,3; j=2,3)$，则
+                \[
+                    A/C = \begin{pmatrix}
+                        P_{22} & P_{23} \\
+                        P_{32} & P_{33}
+                    \end{pmatrix}, \enspace
+                    B/C = P_{22}.
+                \]
+                故
+                \[
+                    (A/C)/(B/C) = P_{33} - P_{32} P_{22}^{-1} P_{23}.
+                \]
+
+                由分块矩阵初等变换可以求得
+                \[
+                    \begin{pmatrix}
+                        A_{11} & A_{12} \\
+                        A_{21} & A_{22}
+                    \end{pmatrix}^{-1} = \begin{pmatrix}
+                        A_{11}^{-1} + A_{11}^{-1} A_{12} P_{22}^{-1} A_{21} A_{11}^{-1} & -A_{11}^{-1} A_{12} P_{22}^{-1} \\
+                        -P_{22}^{-1} A_{21} A_{11}^{-1} & P_{22}^{-1}
+                    \end{pmatrix},
+                \]
+                由此可得
+                \begin{align*}
+                    A/B = {} & A_{33} - \begin{pmatrix}
+                        A_{31} & A_{32}
+                    \end{pmatrix} \begin{pmatrix}
+                        A_{11}^{-1} + A_{11}^{-1} A_{12} P_{22}^{-1} A_{21} A_{11}^{-1} & -A_{11}^{-1} A_{12} P_{22}^{-1} \\
+                        -P_{22}^{-1} A_{21} A_{11}^{-1} & P_{22}^{-1}
+                    \end{pmatrix} \begin{pmatrix}
+                        A_{13} \\ A_{23}
+                    \end{pmatrix} \\
+                    = {} & A_{33} - A_{31} \left(A_{11}^{-1} + A_{11}^{-1} A_{12} P_{22}^{-1} A_{21} A_{11}^{-1}\right) - A_{31} \left(-A_{11}^{-1} A_{12} P_{22}^{-1}\right) - \\
+                      {} & A_{32} \left(-P_{22}^{-1} A_{21} A_{11}^{-1}\right) - A_{32} P_{22}^{-1} A_{23} \\
+                    = {} & \left(A_{33} - A_{31} A_{11}^{-1} A_{13}\right) - \left(A_{32} - A_{31} A_{11}^{-1} A_{12}\right) P_{22}^{-1} \left(A_{23} - A_{21} A_{11}^{-1} A_{13}\right) \\
+                    = {} & P_{33} - P_{32} P_{22}^{-1} P_{23} \\
+                    = {} & (A/C)/(B/C).
+                \end{align*}
+        \end{answer}
 
         \item 已知$A$是一个$s \times n$矩阵，证明：$r(E_n-A^\mathrm{T}A)-r(E_s-AA^\mathrm{T})=n-s$.
+        \begin{answer}
+            令
+            \[
+                B = \begin{pmatrix}
+                    E_n & A^\mathrm{T} \\
+                    A   & E_s
+                \end{pmatrix},
+            \]
+            对 $B$ 做分块倍加变化，有
+            \begin{gather*}
+                \begin{pmatrix}
+                    E_n & A^\mathrm{T} \\
+                    A   & E_s
+                \end{pmatrix} \to \begin{pmatrix}
+                    E_n - A^\mathrm{T}A & A^\mathrm{T} \\
+                    O                   & E_s
+                \end{pmatrix} \to \begin{pmatrix}
+                    E_n - A^\mathrm{T}A & O   \\
+                    O                   & E_s
+                \end{pmatrix}, \\
+                \begin{pmatrix}
+                    E_n & A^\mathrm{T} \\
+                    A   & E_s
+                \end{pmatrix} \to \begin{pmatrix}
+                    E_n & A^\mathrm{T}        \\
+                    O   & E_s - AA^\mathrm{T}
+                \end{pmatrix} \to \begin{pmatrix}
+                    E_n & O                   \\
+                    O   & E_s - AA^\mathrm{T}
+                \end{pmatrix}.
+            \end{gather*}
+            分块倍加变换不改变矩阵的秩，故有
+            \begin{align*}
+                r(B) &= r\begin{pmatrix}
+                    E_n - A^\mathrm{T}A & O   \\
+                    O                   & E_s
+                \end{pmatrix} = r(E_n - A^\mathrm{T}A) + s, \\
+                r(B) &= r\begin{pmatrix}
+                    E_n & O                   \\
+                    O   & E_s - AA^\mathrm{T}
+                \end{pmatrix} = r(E_s - AA^\mathrm{T}) + n.
+            \end{align*}
+            于是有 $r(E_n-A^\mathrm{T}A)-r(E_s-AA^\mathrm{T})=n-s$.
+        \end{answer}
 
         \item 利用打洞法完成以下两个问题（\ref*{item:11:C:1} 也可以不使用打洞法，可以思考其他方式解决）：
         \begin{enumerate}
@@ -1288,13 +2028,73 @@
             \item \label{item:11:C:1}
                   $n$阶方阵$A,B$满足$AB=BA$，证明：$r(AB)+r(A+B)\leqslant r(A)+r(B)$.
         \end{enumerate}
+        \begin{answer}
+            \begin{enumerate}
+                \item 由 \[\begin{pmatrix}A & 0 \\ 0 & B\end{pmatrix}\rightarrow \begin{pmatrix}A & AC \\ 0 & B\end{pmatrix}\rightarrow \begin{pmatrix}A & AC+BD \\ 0 & B\end{pmatrix}=\begin{pmatrix}A & E \\ 0 & B\end{pmatrix}\]
+                      \[\rightarrow \begin{pmatrix}0 & E \\ -AB & B\end{pmatrix}\rightarrow \begin{pmatrix}0 & E \\ AB & 0\end{pmatrix}\]
+                      可得.
+
+                \item 用分块矩阵的方法，我们知道
+                      \[\begin{pmatrix}A & O \\ O & B\end{pmatrix}\rightarrow \begin{pmatrix}A & O \\ A & B\end{pmatrix}\rightarrow \begin{pmatrix}A & A \\ A & A+B\end{pmatrix}\]
+                      结合 $AB=BA$，我们知道
+                      \[\begin{pmatrix}A & A \\ A & A+B\end{pmatrix}\begin{pmatrix}A+B & O \\ -A & E\end{pmatrix}=\begin{pmatrix}AB & A \\ O & A+B\end{pmatrix}\]
+                      于是
+                      \[r(A)+r(B)=r\begin{pmatrix}A & O \\ O & B\end{pmatrix}=r\begin{pmatrix}A & A \\ A & A+B\end{pmatrix}\geqslant \begin{pmatrix}AB & A \\ O & A+B\end{pmatrix}\geqslant r(AB)+r(A+B)\]
+            \end{enumerate}
+        \end{answer}
 
         \item $f(x)=f_1(x)f_2(x)$是多项式，且$f_1(x)$与$f_2(x)$互素，则$f(A)=O$的充要条件是$r(f_1(A))+r(f_2(A))=n$. （注：此题的推论非常多，如$A^2=A$，$A^n=E$等形式的结论都可以利用这个例子推导出）
+        \begin{answer}
+            略有超纲，使用贝祖定理. $\exists u(x),v(x),u(x)f_1(x)+v(x)f_2(x)=1 $，于是
+            \begin{align*}
+                r\begin{pmatrix}
+                    f_1(A) & O      \\
+                    O      & f_2(A)
+                \end{pmatrix}
+                &= r\begin{pmatrix}
+                        f_1(A) & f_1(A)u(A)+f_2(A)v(A) \\
+                        O      & f_2(A)
+                    \end{pmatrix} = r\begin{pmatrix}
+                        f_1(A) & E_n    \\
+                        O      & f_2(A)
+                    \end{pmatrix} \\
+                &= r\begin{pmatrix}
+                        f_1(A)        & E_n \\
+                        -f_2(A)f_1(A) & O
+                    \end{pmatrix} = r\begin{pmatrix}
+                        O    & E_n \\
+                        f(A) & O
+                    \end{pmatrix}.
+            \end{align*}
+            因此
+            \[
+                f(A) = O \iff
+                r\begin{pmatrix}
+                    f_1(A) & O      \\
+                    O      & f_2(A)
+                \end{pmatrix} = r\begin{pmatrix}
+                    O    & E_n \\
+                    f(A) & O
+                \end{pmatrix} = n \iff
+                r(f_1(A)) + r(f_2(A)) = n.
+            \]
+        \end{answer}
 
         \item 设$A,B$分别为$3 \times 2$和$2 \times 3$实矩阵. 若$AB=\begin{pmatrix}
                 8             & 0 & -4 \\[1ex]
                 -\dfrac{3}{2} & 9 & -6 \\[1ex]
                 -2            & 0 & 1
             \end{pmatrix}$，求$BA$.
+        \begin{answer}
+            由于 $A$ 是列满秩矩阵，$B$ 是行满秩矩阵，知存在可逆矩阵 $P_{3\times 3},Q_{2\times 2}$ 使得
+            \[A=P\begin{pmatrix}E_2 \\ O\end{pmatrix},B=\begin{pmatrix}E_2 & O\end{pmatrix}Q,\]
+            于是
+            \[BA=\begin{pmatrix}E_2 & O\end{pmatrix}QP\begin{pmatrix}E_2 \\ O\end{pmatrix}.\]
+            由 $(AB)^2=9AB$ 有 \[P\begin{pmatrix}E_2 \\ O\end{pmatrix}\begin{pmatrix}E_2 & O\end{pmatrix}QP\begin{pmatrix}E_2 \\ O\end{pmatrix}\begin{pmatrix}E_2 & O\end{pmatrix}Q=9P\begin{pmatrix}E_2 \\ O\end{pmatrix}\begin{pmatrix}E_2 & O\end{pmatrix}Q,\]
+            即
+            \[\begin{pmatrix}E_2 \\ O\end{pmatrix}BA\begin{pmatrix}E_2 & O\end{pmatrix}=9\begin{pmatrix}E_2 \\ O\end{pmatrix}\begin{pmatrix}E_2 & O\end{pmatrix},\]
+            也就是 \[\begin{pmatrix}BA & O \\ O & O\end{pmatrix}=\begin{pmatrix}9E_2 & 0 \\ 0 & 0\end{pmatrix}.\]
+            所以 $BA=9E_2$.
+        \end{answer}
     \end{exgroup}
 \end{exercise}


### PR DESCRIPTION
- 第 3, 9, 12 章答案已补全，除了第 3 章 C 组的最后一题；
- 第 12 章 B 组 25 题答案中 `\iddots` 会报 Undefined control sequence 错误，暂时将其删去；
- 第 12 章原本的例 12.20 与例 12.24 相同（柯西行列式），故将原本的例 12.20 删去；
- 另外修了一些习题中的格式错误.